### PR TITLE
Add Slice method for EoReader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.20
 require (
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
+	golang.org/x/text v0.11.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/text v0.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/eolib/protocol/net/server/structs_generated.go
+++ b/pkg/eolib/protocol/net/server/structs_generated.go
@@ -1172,8 +1172,8 @@ func (s *PubFile) Deserialize(reader data.EoReader) (err error) {
 
 // PlayersList :: Information about online players.
 type PlayersList struct {
-	OnlineCount int
-	Players     []OnlinePlayer
+	PlayersCount int
+	Players      []OnlinePlayer
 }
 
 func (s *PlayersList) Serialize(writer data.EoWriter) (err error) {
@@ -1181,14 +1181,14 @@ func (s *PlayersList) Serialize(writer data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	writer.SanitizeStrings = true
-	// OnlineCount : field : short
-	if err = writer.AddShort(s.OnlineCount); err != nil {
+	// PlayersCount : length : short
+	if err = writer.AddShort(s.PlayersCount); err != nil {
 		return
 	}
 
 	writer.AddByte(0xFF)
 	// Players : array : OnlinePlayer
-	for ndx := 0; ndx < len(s.Players); ndx++ {
+	for ndx := 0; ndx < s.PlayersCount; ndx++ {
 		if err = s.Players[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -1204,13 +1204,13 @@ func (s *PlayersList) Deserialize(reader data.EoReader) (err error) {
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
 	reader.SetIsChunked(true)
-	// OnlineCount : field : short
-	s.OnlineCount = reader.GetShort()
+	// PlayersCount : length : short
+	s.PlayersCount = reader.GetShort()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
 	// Players : array : OnlinePlayer
-	for ndx := 0; reader.Remaining() > 0; ndx++ {
+	for ndx := 0; ndx < s.PlayersCount; ndx++ {
 		s.Players = append(s.Players, OnlinePlayer{})
 		if err = s.Players[ndx].Deserialize(reader); err != nil {
 			return
@@ -1227,8 +1227,8 @@ func (s *PlayersList) Deserialize(reader data.EoReader) (err error) {
 
 // PlayersListFriends ::  Information about online players. Sent in reply to friends list requests.
 type PlayersListFriends struct {
-	OnlineCount int
-	Players     []string
+	PlayersCount int
+	Players      []string
 }
 
 func (s *PlayersListFriends) Serialize(writer data.EoWriter) (err error) {
@@ -1236,14 +1236,14 @@ func (s *PlayersListFriends) Serialize(writer data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	writer.SanitizeStrings = true
-	// OnlineCount : field : short
-	if err = writer.AddShort(s.OnlineCount); err != nil {
+	// PlayersCount : length : short
+	if err = writer.AddShort(s.PlayersCount); err != nil {
 		return
 	}
 
 	writer.AddByte(0xFF)
 	// Players : array : string
-	for ndx := 0; ndx < len(s.Players); ndx++ {
+	for ndx := 0; ndx < s.PlayersCount; ndx++ {
 		if err = writer.AddString(s.Players[ndx]); err != nil {
 			return
 		}
@@ -1260,13 +1260,13 @@ func (s *PlayersListFriends) Deserialize(reader data.EoReader) (err error) {
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
 	reader.SetIsChunked(true)
-	// OnlineCount : field : short
-	s.OnlineCount = reader.GetShort()
+	// PlayersCount : length : short
+	s.PlayersCount = reader.GetShort()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
 	// Players : array : string
-	for ndx := 0; reader.Remaining() > 0; ndx++ {
+	for ndx := 0; ndx < s.PlayersCount; ndx++ {
 		if s.Players[ndx], err = reader.GetString(); err != nil {
 			return
 		}


### PR DESCRIPTION
Returns a new reader with a slice of the underlying data.

This is useful in the case of INIT_INIT packets for friend list or online player list. Since `PacketFamily_Init` and `PacketAction_Init` are `255` bytes, they are treated as break bytes by the reader which causes issues.

`Slice` should be called prior to reading packet data, but after the handling of sequence numbers in the packet.