### PR TITLE
Add support for optional values from protocol XML (and other codegen bug fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Core library for writing Endless Online applications using the Go programming la
 The library may be referenced in a project via go get:
 
 ```
-go get github.com/ethanmoffat/eolib-go@v1.1.0
+go get github.com/ethanmoffat/eolib-go@v1.1.1
 ```
 
 ### Sample code

--- a/internal/codegen/struct.go
+++ b/internal/codegen/struct.go
@@ -729,6 +729,7 @@ func writeGetTypeForDeserialize(output *strings.Builder, instructionName string,
 		output.WriteString(fmt.Sprintf("\treader.Get%s(%s)\n", methodType, lengthExpr))
 	} else {
 		if instruction.XMLName.Local == "array" {
+			output.WriteString(fmt.Sprintf("\t\ts.%s = append(s.%s, 0)\n", instructionName, instructionName))
 			instructionName = instructionName + "[ndx]"
 		}
 
@@ -804,6 +805,7 @@ func writeGetStringTypeForDeserialize(output *strings.Builder, instructionName s
 		output.WriteString(fmt.Sprintf("\tif _, err = reader.Get%s(%s); err != nil {\n\t\treturn\n\t}\n", methodType, lengthExpr))
 	} else {
 		if instruction.XMLName.Local == "array" {
+			output.WriteString(fmt.Sprintf("\t\ts.%s = append(s.%s, \"\")\n", instructionName, instructionName))
 			instructionName = instructionName + "[ndx]"
 		}
 

--- a/internal/codegen/struct.go
+++ b/internal/codegen/struct.go
@@ -697,10 +697,10 @@ func writeAddTypeForSerialize(output *strings.Builder, instructionName string, i
 		instructionName = "int(" + instructionName + ")"
 	}
 
-	output.WriteString(fmt.Sprintf("\t\tif err = writer.Add%s(%s); err != nil {\n\t\t\treturn\n\t\t}\n\n", methodType, instructionName))
+	output.WriteString(fmt.Sprintf("\t\tif err = writer.Add%s(%s); err != nil {\n\t\t\treturn\n\t\t}\n", methodType, instructionName))
 
 	if optional {
-		output.WriteString("\t}\n\n")
+		output.WriteString("\t}\n")
 	}
 }
 
@@ -777,10 +777,10 @@ func writeAddStringTypeForSerialize(output *strings.Builder, instructionName str
 		instructionName = "*" + instructionName
 	}
 
-	output.WriteString(fmt.Sprintf("\t\tif err = writer.Add%s(%s); err != nil {\n\t\t\treturn\n\t\t}\n\n", methodType, instructionName))
+	output.WriteString(fmt.Sprintf("\t\tif err = writer.Add%s(%s); err != nil {\n\t\t\treturn\n\t\t}\n", methodType, instructionName))
 
 	if optional {
-		output.WriteString("\t}\n\n")
+		output.WriteString("\t}\n")
 	}
 }
 

--- a/pkg/eolib/protocol/map/structs_generated.go
+++ b/pkg/eolib/protocol/map/structs_generated.go
@@ -751,6 +751,7 @@ func (s *Emf) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Rid = append(s.Rid, 0)
 		s.Rid[ndx] = reader.GetShort()
 	}
 

--- a/pkg/eolib/protocol/map/structs_generated.go
+++ b/pkg/eolib/protocol/map/structs_generated.go
@@ -30,22 +30,18 @@ func (s *MapNpc) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Id); err != nil {
 		return
 	}
-
 	// SpawnType : field : char
 	if err = writer.AddChar(s.SpawnType); err != nil {
 		return
 	}
-
 	// SpawnTime : field : short
 	if err = writer.AddShort(s.SpawnTime); err != nil {
 		return
 	}
-
 	// Amount : field : char
 	if err = writer.AddChar(s.Amount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -87,7 +83,6 @@ func (s *MapLegacyDoorKey) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Key); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -127,27 +122,22 @@ func (s *MapItem) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Key); err != nil {
 		return
 	}
-
 	// ChestSlot : field : char
 	if err = writer.AddChar(s.ChestSlot); err != nil {
 		return
 	}
-
 	// ItemId : field : short
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	// SpawnTime : field : short
 	if err = writer.AddShort(s.SpawnTime); err != nil {
 		return
 	}
-
 	// Amount : field : three
 	if err = writer.AddThree(s.Amount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -189,7 +179,6 @@ func (s *MapWarp) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.DestinationMap); err != nil {
 		return
 	}
-
 	// DestinationCoords : field : Coords
 	if err = s.DestinationCoords.Serialize(writer); err != nil {
 		return
@@ -198,12 +187,10 @@ func (s *MapWarp) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.LevelRequired); err != nil {
 		return
 	}
-
 	// Door : field : short
 	if err = writer.AddShort(s.Door); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -245,17 +232,14 @@ func (s *MapSign) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.StringDataLength); err != nil {
 		return
 	}
-
 	// StringData : field : encoded_string
 	if err = writer.AddFixedEncodedString(s.StringData, s.StringDataLength); err != nil {
 		return
 	}
-
 	// TitleLength : field : char
 	if err = writer.AddChar(s.TitleLength); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -294,12 +278,10 @@ func (s *MapTileSpecRowTile) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.X); err != nil {
 		return
 	}
-
 	// TileSpec : field : MapTileSpec
 	if err = writer.AddChar(int(s.TileSpec)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -330,12 +312,10 @@ func (s *MapTileSpecRow) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Y); err != nil {
 		return
 	}
-
 	// TilesCount : length : char
 	if err = writer.AddChar(s.TilesCount); err != nil {
 		return
 	}
-
 	// Tiles : array : MapTileSpecRowTile
 	for ndx := 0; ndx < s.TilesCount; ndx++ {
 		if err = s.Tiles[ndx].Serialize(writer); err != nil {
@@ -379,7 +359,6 @@ func (s *MapWarpRowTile) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.X); err != nil {
 		return
 	}
-
 	// Warp : field : MapWarp
 	if err = s.Warp.Serialize(writer); err != nil {
 		return
@@ -416,12 +395,10 @@ func (s *MapWarpRow) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Y); err != nil {
 		return
 	}
-
 	// TilesCount : length : char
 	if err = writer.AddChar(s.TilesCount); err != nil {
 		return
 	}
-
 	// Tiles : array : MapWarpRowTile
 	for ndx := 0; ndx < s.TilesCount; ndx++ {
 		if err = s.Tiles[ndx].Serialize(writer); err != nil {
@@ -465,12 +442,10 @@ func (s *MapGraphicRowTile) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.X); err != nil {
 		return
 	}
-
 	// Graphic : field : short
 	if err = writer.AddShort(s.Graphic); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -501,12 +476,10 @@ func (s *MapGraphicRow) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Y); err != nil {
 		return
 	}
-
 	// TilesCount : length : char
 	if err = writer.AddChar(s.TilesCount); err != nil {
 		return
 	}
-
 	// Tiles : array : MapGraphicRowTile
 	for ndx := 0; ndx < s.TilesCount; ndx++ {
 		if err = s.Tiles[ndx].Serialize(writer); err != nil {
@@ -550,7 +523,6 @@ func (s *MapGraphicLayer) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.GraphicRowsCount); err != nil {
 		return
 	}
-
 	// GraphicRows : array : MapGraphicRow
 	for ndx := 0; ndx < s.GraphicRowsCount; ndx++ {
 		if err = s.GraphicRows[ndx].Serialize(writer); err != nil {
@@ -618,60 +590,49 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddFixedString("EMF", 3); err != nil {
 		return
 	}
-
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.Rid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// Name : field : encoded_string
 	if err = writer.AddPaddedEncodedString(s.Name, 24); err != nil {
 		return
 	}
-
 	// Type : field : MapType
 	if err = writer.AddChar(int(s.Type)); err != nil {
 		return
 	}
-
 	// TimedEffect : field : MapTimedEffect
 	if err = writer.AddChar(int(s.TimedEffect)); err != nil {
 		return
 	}
-
 	// MusicId : field : char
 	if err = writer.AddChar(s.MusicId); err != nil {
 		return
 	}
-
 	// MusicControl : field : MapMusicControl
 	if err = writer.AddChar(int(s.MusicControl)); err != nil {
 		return
 	}
-
 	// AmbientSoundId : field : short
 	if err = writer.AddShort(s.AmbientSoundId); err != nil {
 		return
 	}
-
 	// Width : field : char
 	if err = writer.AddChar(s.Width); err != nil {
 		return
 	}
-
 	// Height : field : char
 	if err = writer.AddChar(s.Height); err != nil {
 		return
 	}
-
 	// FillTile : field : short
 	if err = writer.AddShort(s.FillTile); err != nil {
 		return
 	}
-
 	// MapAvailable : field : bool
 	if s.MapAvailable {
 		err = writer.AddChar(1)
@@ -696,22 +657,18 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.RelogX); err != nil {
 		return
 	}
-
 	// RelogY : field : char
 	if err = writer.AddChar(s.RelogY); err != nil {
 		return
 	}
-
 	//  : field : char
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	// NpcsCount : length : char
 	if err = writer.AddChar(s.NpcsCount); err != nil {
 		return
 	}
-
 	// Npcs : array : MapNpc
 	for ndx := 0; ndx < s.NpcsCount; ndx++ {
 		if err = s.Npcs[ndx].Serialize(writer); err != nil {
@@ -723,7 +680,6 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.LegacyDoorKeysCount); err != nil {
 		return
 	}
-
 	// LegacyDoorKeys : array : MapLegacyDoorKey
 	for ndx := 0; ndx < s.LegacyDoorKeysCount; ndx++ {
 		if err = s.LegacyDoorKeys[ndx].Serialize(writer); err != nil {
@@ -735,7 +691,6 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.ItemsCount); err != nil {
 		return
 	}
-
 	// Items : array : MapItem
 	for ndx := 0; ndx < s.ItemsCount; ndx++ {
 		if err = s.Items[ndx].Serialize(writer); err != nil {
@@ -747,7 +702,6 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.TileSpecRowsCount); err != nil {
 		return
 	}
-
 	// TileSpecRows : array : MapTileSpecRow
 	for ndx := 0; ndx < s.TileSpecRowsCount; ndx++ {
 		if err = s.TileSpecRows[ndx].Serialize(writer); err != nil {
@@ -759,7 +713,6 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.WarpRowsCount); err != nil {
 		return
 	}
-
 	// WarpRows : array : MapWarpRow
 	for ndx := 0; ndx < s.WarpRowsCount; ndx++ {
 		if err = s.WarpRows[ndx].Serialize(writer); err != nil {
@@ -778,7 +731,6 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.SignsCount); err != nil {
 		return
 	}
-
 	// Signs : array : MapSign
 	for ndx := 0; ndx < s.SignsCount; ndx++ {
 		if err = s.Signs[ndx].Serialize(writer); err != nil {

--- a/pkg/eolib/protocol/net/client/packets_generated.go
+++ b/pkg/eolib/protocol/net/client/packets_generated.go
@@ -2442,6 +2442,7 @@ func (s *CitizenReplyClientPacket) Deserialize(reader *data.EoReader) (err error
 	}
 	// Answers : array : string
 	for ndx := 0; ndx < 3; ndx++ {
+		s.Answers = append(s.Answers, "")
 		if s.Answers[ndx], err = reader.GetString(); err != nil {
 			return
 		}
@@ -4027,6 +4028,7 @@ func (s *RangeRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 	reader.SetIsChunked(true)
 	// PlayerIds : array : short
 	for ndx := 0; ndx < reader.Remaining()/2; ndx++ {
+		s.PlayerIds = append(s.PlayerIds, 0)
 		s.PlayerIds[ndx] = reader.GetShort()
 	}
 
@@ -4035,6 +4037,7 @@ func (s *RangeRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 	}
 	// NpcIndexes : array : char
 	for ndx := 0; ndx < reader.Remaining()/1; ndx++ {
+		s.NpcIndexes = append(s.NpcIndexes, 0)
 		s.NpcIndexes[ndx] = reader.GetChar()
 	}
 
@@ -4076,6 +4079,7 @@ func (s *PlayerRangeRequestClientPacket) Deserialize(reader *data.EoReader) (err
 
 	// PlayerIds : array : short
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
+		s.PlayerIds = append(s.PlayerIds, 0)
 		s.PlayerIds[ndx] = reader.GetShort()
 	}
 
@@ -4129,6 +4133,7 @@ func (s *NpcRangeRequestClientPacket) Deserialize(reader *data.EoReader) (err er
 	reader.GetByte()
 	// NpcIndexes : array : char
 	for ndx := 0; ndx < s.NpcIndexesLength; ndx++ {
+		s.NpcIndexes = append(s.NpcIndexes, 0)
 		s.NpcIndexes[ndx] = reader.GetChar()
 	}
 
@@ -4492,6 +4497,7 @@ func (s *GuildAgreeInfoTypeDataRanks) Deserialize(reader *data.EoReader) (err er
 
 	// Ranks : array : string
 	for ndx := 0; ndx < 9; ndx++ {
+		s.Ranks = append(s.Ranks, "")
 		if s.Ranks[ndx], err = reader.GetString(); err != nil {
 			return
 		}

--- a/pkg/eolib/protocol/net/client/packets_generated.go
+++ b/pkg/eolib/protocol/net/client/packets_generated.go
@@ -35,7 +35,6 @@ func (s *InitInitClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddThree(s.Challenge); err != nil {
 		return
 	}
-
 	// Version : field : Version
 	if err = s.Version.Serialize(writer); err != nil {
 		return
@@ -44,17 +43,14 @@ func (s *InitInitClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(112); err != nil {
 		return
 	}
-
 	// HdidLength : length : char
 	if err = writer.AddChar(s.HdidLength); err != nil {
 		return
 	}
-
 	// Hdid : field : string
 	if err = writer.AddFixedString(s.Hdid, s.HdidLength); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -103,17 +99,14 @@ func (s *ConnectionAcceptClientPacket) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddShort(s.ClientEncryptionMultiple); err != nil {
 		return
 	}
-
 	// ServerEncryptionMultiple : field : short
 	if err = writer.AddShort(s.ServerEncryptionMultiple); err != nil {
 		return
 	}
-
 	// PlayerId : field : short
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -151,7 +144,6 @@ func (s *ConnectionPingClientPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddString("k"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -188,7 +180,6 @@ func (s *AccountRequestClientPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddString(s.Username); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -233,49 +224,41 @@ func (s *AccountCreateClientPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Username : field : string
 	if err = writer.AddString(s.Username); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Password : field : string
 	if err = writer.AddString(s.Password); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// FullName : field : string
 	if err = writer.AddString(s.FullName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Location : field : string
 	if err = writer.AddString(s.Location); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Email : field : string
 	if err = writer.AddString(s.Email); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Computer : field : string
 	if err = writer.AddString(s.Computer); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Hdid : field : string
 	if err = writer.AddString(s.Hdid); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -376,19 +359,16 @@ func (s *AccountAgreeClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddString(s.Username); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// OldPassword : field : string
 	if err = writer.AddString(s.OldPassword); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// NewPassword : field : string
 	if err = writer.AddString(s.NewPassword); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -450,7 +430,6 @@ func (s *CharacterRequestClientPacket) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddString(s.RequestString); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -501,33 +480,27 @@ func (s *CharacterCreateClientPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// Gender : field : Gender:short
 	if err = writer.AddChar(int(s.Gender)); err != nil {
 		return
 	}
-
 	// HairStyle : field : short
 	if err = writer.AddShort(s.HairStyle); err != nil {
 		return
 	}
-
 	// HairColor : field : short
 	if err = writer.AddShort(s.HairColor); err != nil {
 		return
 	}
-
 	// Skin : field : short
 	if err = writer.AddShort(s.Skin); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Name : field : string
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -585,7 +558,6 @@ func (s *CharacterTakeClientPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddInt(s.CharacterId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -621,12 +593,10 @@ func (s *CharacterRemoveClientPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// CharacterId : field : int
 	if err = writer.AddInt(s.CharacterId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -665,13 +635,11 @@ func (s *LoginRequestClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddString(s.Username); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Password : field : string
 	if err = writer.AddString(s.Password); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -724,7 +692,6 @@ func (s *WelcomeRequestClientPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddInt(s.CharacterId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -760,12 +727,10 @@ func (s *WelcomeMsgClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddThree(s.SessionId); err != nil {
 		return
 	}
-
 	// CharacterId : field : int
 	if err = writer.AddInt(s.CharacterId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -804,7 +769,6 @@ func (s *WelcomeAgreeFileTypeDataEmf) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddShort(s.FileId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -830,7 +794,6 @@ func (s *WelcomeAgreeFileTypeDataEif) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddChar(s.FileId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -856,7 +819,6 @@ func (s *WelcomeAgreeFileTypeDataEnf) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddChar(s.FileId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -882,7 +844,6 @@ func (s *WelcomeAgreeFileTypeDataEsf) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddChar(s.FileId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -908,7 +869,6 @@ func (s *WelcomeAgreeFileTypeDataEcf) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddChar(s.FileId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -938,12 +898,10 @@ func (s *WelcomeAgreeClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddChar(int(s.FileType)); err != nil {
 		return
 	}
-
 	// SessionId : field : short
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	switch s.FileType {
 	case File_Emf:
 		switch s.FileTypeData.(type) {
@@ -1059,7 +1017,6 @@ func (s *AdminInteractTellClientPacket) Serialize(writer *data.EoWriter) (err er
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1098,13 +1055,11 @@ func (s *AdminInteractReportClientPacket) Serialize(writer *data.EoWriter) (err 
 	if err = writer.AddString(s.Reportee); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -1152,7 +1107,6 @@ func (s *GlobalRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddString("n"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1188,7 +1142,6 @@ func (s *GlobalPlayerClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddString("y"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1224,7 +1177,6 @@ func (s *GlobalOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString("y"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1260,7 +1212,6 @@ func (s *GlobalCloseClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString("n"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1297,7 +1248,6 @@ func (s *TalkRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1334,7 +1284,6 @@ func (s *TalkOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1371,7 +1320,6 @@ func (s *TalkMsgClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1410,13 +1358,11 @@ func (s *TalkTellClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -1465,7 +1411,6 @@ func (s *TalkReportClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1502,7 +1447,6 @@ func (s *TalkPlayerClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1539,7 +1483,6 @@ func (s *TalkUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1576,7 +1519,6 @@ func (s *TalkAdminClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1613,7 +1555,6 @@ func (s *TalkAnnounceClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1651,12 +1592,10 @@ func (s *AttackUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	// Timestamp : field : three
 	if err = writer.AddThree(s.Timestamp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1725,7 +1664,6 @@ func (s *ChairRequestClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddChar(int(s.SitAction)); err != nil {
 		return
 	}
-
 	switch s.SitAction {
 	case SitAction_Sit:
 		switch s.SitActionData.(type) {
@@ -1811,7 +1749,6 @@ func (s *SitRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.SitAction)); err != nil {
 		return
 	}
-
 	switch s.SitAction {
 	case SitAction_Sit:
 		switch s.SitActionData.(type) {
@@ -1865,7 +1802,6 @@ func (s *EmoteReportClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Emote)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1900,7 +1836,6 @@ func (s *FacePlayerClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2043,7 +1978,6 @@ func (s *BankOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2078,7 +2012,6 @@ func (s *BankAddClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.Amount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2113,7 +2046,6 @@ func (s *BankTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.Amount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2150,17 +2082,14 @@ func (s *BarberBuyClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.HairStyle); err != nil {
 		return
 	}
-
 	// HairColor : field : char
 	if err = writer.AddChar(s.HairColor); err != nil {
 		return
 	}
-
 	// SessionId : field : int
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2199,7 +2128,6 @@ func (s *BarberOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2284,7 +2212,6 @@ func (s *LockerTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.TakeItemId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2358,7 +2285,6 @@ func (s *LockerBuyClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(1); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2394,12 +2320,10 @@ func (s *CitizenRequestClientPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// BehaviorId : field : short
 	if err = writer.AddShort(s.BehaviorId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2437,12 +2361,10 @@ func (s *CitizenAcceptClientPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// BehaviorId : field : short
 	if err = writer.AddShort(s.BehaviorId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2482,13 +2404,11 @@ func (s *CitizenReplyClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// BehaviorId : field : short
 	if err = writer.AddShort(s.BehaviorId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Answers : array : string
 	for ndx := 0; ndx < 3; ndx++ {
@@ -2499,7 +2419,6 @@ func (s *CitizenReplyClientPacket) Serialize(writer *data.EoWriter) (err error) 
 		if err = writer.AddString(s.Answers[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	writer.SanitizeStrings = false
@@ -2560,7 +2479,6 @@ func (s *CitizenRemoveClientPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.BehaviorId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2595,7 +2513,6 @@ func (s *CitizenOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2631,12 +2548,10 @@ func (s *ShopCreateClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.CraftItemId); err != nil {
 		return
 	}
-
 	// SessionId : field : int
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2678,7 +2593,6 @@ func (s *ShopBuyClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2722,7 +2636,6 @@ func (s *ShopSellClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2761,7 +2674,6 @@ func (s *ShopOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2796,7 +2708,6 @@ func (s *StatSkillOpenClientPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2832,12 +2743,10 @@ func (s *StatSkillTakeClientPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	// SpellId : field : short
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2875,12 +2784,10 @@ func (s *StatSkillRemoveClientPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	// SpellId : field : short
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2918,7 +2825,6 @@ func (s *StatSkillAddActionTypeDataStat) Serialize(writer *data.EoWriter) (err e
 	if err = writer.AddShort(int(s.StatId)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2944,7 +2850,6 @@ func (s *StatSkillAddActionTypeDataSkill) Serialize(writer *data.EoWriter) (err 
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2974,7 +2879,6 @@ func (s *StatSkillAddClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddChar(int(s.ActionType)); err != nil {
 		return
 	}
-
 	switch s.ActionType {
 	case Train_Stat:
 		switch s.ActionTypeData.(type) {
@@ -3043,7 +2947,6 @@ func (s *StatSkillJunkClientPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3078,7 +2981,6 @@ func (s *ItemUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3194,7 +3096,6 @@ func (s *ItemGetClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.ItemIndex); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3230,12 +3131,10 @@ func (s *BoardRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.BoardId); err != nil {
 		return
 	}
-
 	// PostId : field : short
 	if err = writer.AddShort(s.PostId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3275,19 +3174,16 @@ func (s *BoardCreateClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.BoardId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// PostSubject : field : string
 	if err = writer.AddString(s.PostSubject); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// PostBody : field : string
 	if err = writer.AddString(s.PostBody); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -3346,12 +3242,10 @@ func (s *BoardTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.BoardId); err != nil {
 		return
 	}
-
 	// PostId : field : short
 	if err = writer.AddShort(s.PostId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3388,7 +3282,6 @@ func (s *BoardOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.BoardId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3460,17 +3353,14 @@ func (s *JukeboxMsgClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	//  : field : char
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	// TrackId : field : short
 	if err = writer.AddShort(s.TrackId); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -3513,12 +3403,10 @@ func (s *JukeboxUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.InstrumentId); err != nil {
 		return
 	}
-
 	// NoteId : field : char
 	if err = writer.AddChar(s.NoteId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3556,12 +3444,10 @@ func (s *WarpAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.MapId); err != nil {
 		return
 	}
-
 	// SessionId : field : short
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3599,12 +3485,10 @@ func (s *WarpTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.MapId); err != nil {
 		return
 	}
-
 	// SessionId : field : short
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3641,7 +3525,6 @@ func (s *PaperdollRequestClientPacket) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3677,12 +3560,10 @@ func (s *PaperdollRemoveClientPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	// SubLoc : field : char
 	if err = writer.AddChar(s.SubLoc); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3720,12 +3601,10 @@ func (s *PaperdollAddClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	// SubLoc : field : char
 	if err = writer.AddChar(s.SubLoc); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3762,7 +3641,6 @@ func (s *BookRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3796,7 +3674,6 @@ func (s *MessagePingClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(2); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3831,7 +3708,6 @@ func (s *PlayersAcceptClientPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3867,7 +3743,6 @@ func (s *PlayersRequestClientPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddByte(255); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3901,7 +3776,6 @@ func (s *PlayersListClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddByte(255); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4058,7 +3932,6 @@ func (s *ChestTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.TakeItemId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4096,7 +3969,6 @@ func (s *RefreshRequestClientPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddByte(255); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4134,7 +4006,6 @@ func (s *RangeRequestClientPacket) Serialize(writer *data.EoWriter) (err error) 
 		if err = writer.AddShort(s.PlayerIds[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	writer.AddByte(0xFF)
@@ -4143,7 +4014,6 @@ func (s *RangeRequestClientPacket) Serialize(writer *data.EoWriter) (err error) 
 		if err = writer.AddChar(s.NpcIndexes[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	writer.SanitizeStrings = false
@@ -4195,7 +4065,6 @@ func (s *PlayerRangeRequestClientPacket) Serialize(writer *data.EoWriter) (err e
 		if err = writer.AddShort(s.PlayerIds[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	return
@@ -4236,18 +4105,15 @@ func (s *NpcRangeRequestClientPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddChar(s.NpcIndexesLength); err != nil {
 		return
 	}
-
 	//  : field : byte
 	if err = writer.AddByte(255); err != nil {
 		return
 	}
-
 	// NpcIndexes : array : char
 	for ndx := 0; ndx < s.NpcIndexesLength; ndx++ {
 		if err = writer.AddChar(s.NpcIndexes[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	return
@@ -4291,12 +4157,10 @@ func (s *PartyRequestClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddChar(int(s.RequestType)); err != nil {
 		return
 	}
-
 	// PlayerId : field : short
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4334,12 +4198,10 @@ func (s *PartyAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.RequestType)); err != nil {
 		return
 	}
-
 	// InviterPlayerId : field : short
 	if err = writer.AddShort(s.InviterPlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4376,7 +4238,6 @@ func (s *PartyRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4411,7 +4272,6 @@ func (s *PartyTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.MembersCount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4449,19 +4309,16 @@ func (s *GuildRequestClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildTag : field : string
 	if err = writer.AddString(s.GuildTag); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildName : field : string
 	if err = writer.AddString(s.GuildName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -4519,12 +4376,10 @@ func (s *GuildAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(20202); err != nil {
 		return
 	}
-
 	// InviterPlayerId : field : short
 	if err = writer.AddShort(s.InviterPlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4561,7 +4416,6 @@ func (s *GuildRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4598,7 +4452,6 @@ func (s *GuildAgreeInfoTypeDataDescription) Serialize(writer *data.EoWriter) (er
 	if err = writer.AddString(s.Description); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4627,7 +4480,6 @@ func (s *GuildAgreeInfoTypeDataRanks) Serialize(writer *data.EoWriter) (err erro
 		if err = writer.AddString(s.Ranks[ndx]); err != nil {
 			return
 		}
-
 		writer.AddByte(0xFF)
 	}
 
@@ -4666,12 +4518,10 @@ func (s *GuildAgreeClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	// InfoType : field : GuildInfoType
 	if err = writer.AddShort(int(s.InfoType)); err != nil {
 		return
 	}
-
 	switch s.InfoType {
 	case GuildInfo_Description:
 		switch s.InfoTypeData.(type) {
@@ -4749,25 +4599,21 @@ func (s *GuildCreateClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildTag : field : string
 	if err = writer.AddString(s.GuildTag); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildName : field : string
 	if err = writer.AddString(s.GuildName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Description : field : string
 	if err = writer.AddString(s.Description); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -4836,19 +4682,16 @@ func (s *GuildPlayerClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildTag : field : string
 	if err = writer.AddString(s.GuildTag); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// RecruiterName : field : string
 	if err = writer.AddString(s.RecruiterName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -4907,12 +4750,10 @@ func (s *GuildTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	// InfoType : field : GuildInfoType
 	if err = writer.AddShort(int(s.InfoType)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4949,7 +4790,6 @@ func (s *GuildUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4985,12 +4825,10 @@ func (s *GuildBuyClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	// GoldAmount : field : int
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5027,7 +4865,6 @@ func (s *GuildOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5063,12 +4900,10 @@ func (s *GuildTellClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	// GuildIdentity : field : string
 	if err = writer.AddString(s.GuildIdentity); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5108,12 +4943,10 @@ func (s *GuildReportClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	// GuildIdentity : field : string
 	if err = writer.AddString(s.GuildIdentity); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5152,7 +4985,6 @@ func (s *GuildJunkClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5188,12 +5020,10 @@ func (s *GuildKickClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	// MemberName : field : string
 	if err = writer.AddString(s.MemberName); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5234,17 +5064,14 @@ func (s *GuildRankClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	// Rank : field : char
 	if err = writer.AddChar(s.Rank); err != nil {
 		return
 	}
-
 	// MemberName : field : string
 	if err = writer.AddString(s.MemberName); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5286,12 +5113,10 @@ func (s *SpellRequestClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// Timestamp : field : three
 	if err = writer.AddThree(s.Timestamp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5330,17 +5155,14 @@ func (s *SpellTargetSelfClientPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	// SpellId : field : short
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// Timestamp : field : three
 	if err = writer.AddThree(s.Timestamp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5383,27 +5205,22 @@ func (s *SpellTargetOtherClientPacket) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddChar(int(s.TargetType)); err != nil {
 		return
 	}
-
 	// PreviousTimestamp : field : three
 	if err = writer.AddThree(s.PreviousTimestamp); err != nil {
 		return
 	}
-
 	// SpellId : field : short
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// VictimId : field : short
 	if err = writer.AddShort(s.VictimId); err != nil {
 		return
 	}
-
 	// Timestamp : field : three
 	if err = writer.AddThree(s.Timestamp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5447,12 +5264,10 @@ func (s *SpellTargetGroupClientPacket) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// Timestamp : field : three
 	if err = writer.AddThree(s.Timestamp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5489,7 +5304,6 @@ func (s *SpellUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5524,12 +5338,10 @@ func (s *TradeRequestClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddChar(138); err != nil {
 		return
 	}
-
 	// PlayerId : field : short
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5566,12 +5378,10 @@ func (s *TradeAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	// PlayerId : field : short
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5608,7 +5418,6 @@ func (s *TradeRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5722,7 +5531,6 @@ func (s *TradeCloseClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5758,12 +5566,10 @@ func (s *QuestUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	// QuestId : field : short
 	if err = writer.AddShort(s.QuestId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5805,7 +5611,6 @@ func (s *QuestAcceptReplyTypeDataLink) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddChar(s.Action); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5835,27 +5640,22 @@ func (s *QuestAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// DialogId : field : short
 	if err = writer.AddShort(s.DialogId); err != nil {
 		return
 	}
-
 	// QuestId : field : short
 	if err = writer.AddShort(s.QuestId); err != nil {
 		return
 	}
-
 	// NpcIndex : field : short
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	// ReplyType : field : DialogReply
 	if err = writer.AddChar(int(s.ReplyType)); err != nil {
 		return
 	}
-
 	switch s.ReplyType {
 	case DialogReply_Link:
 		switch s.ReplyTypeData.(type) {
@@ -5917,7 +5717,6 @@ func (s *QuestListClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Page)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5952,7 +5751,6 @@ func (s *MarriageOpenClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5990,18 +5788,15 @@ func (s *MarriageRequestClientPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddChar(int(s.RequestType)); err != nil {
 		return
 	}
-
 	// SessionId : field : int
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Name : field : string
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -6049,7 +5844,6 @@ func (s *PriestAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6084,7 +5878,6 @@ func (s *PriestOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.NpcIndex); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6121,13 +5914,11 @@ func (s *PriestRequestClientPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Name : field : string
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -6173,7 +5964,6 @@ func (s *PriestUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 

--- a/pkg/eolib/protocol/net/client/structs_generated.go
+++ b/pkg/eolib/protocol/net/client/structs_generated.go
@@ -23,12 +23,10 @@ func (s *ByteCoords) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddByte(s.X); err != nil {
 		return
 	}
-
 	// Y : field : byte
 	if err = writer.AddByte(s.Y); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -59,12 +57,10 @@ func (s *WalkAction) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	// Timestamp : field : three
 	if err = writer.AddThree(s.Timestamp); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return

--- a/pkg/eolib/protocol/net/server/packets_generated.go
+++ b/pkg/eolib/protocol/net/server/packets_generated.go
@@ -4507,7 +4507,7 @@ func (s *FacePlayerServerPacket) Deserialize(reader *data.EoReader) (err error) 
 // AvatarRemoveServerPacket :: Nearby player has disappeared from view.
 type AvatarRemoveServerPacket struct {
 	PlayerId   int
-	WarpEffect WarpEffect
+	WarpEffect *WarpEffect
 }
 
 func (s AvatarRemoveServerPacket) Family() net.PacketFamily {
@@ -4528,8 +4528,11 @@ func (s *AvatarRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	}
 
 	// WarpEffect : field : WarpEffect
-	if err = writer.AddChar(int(s.WarpEffect)); err != nil {
-		return
+	if s.WarpEffect != nil {
+		if err = writer.AddChar(int(*s.WarpEffect)); err != nil {
+			return
+		}
+
 	}
 
 	return
@@ -4542,7 +4545,10 @@ func (s *AvatarRemoveServerPacket) Deserialize(reader *data.EoReader) (err error
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// WarpEffect : field : WarpEffect
-	s.WarpEffect = WarpEffect(reader.GetChar())
+	if reader.Remaining() > 0 {
+		s.WarpEffect = new(WarpEffect)
+		*s.WarpEffect = WarpEffect(reader.GetChar())
+	}
 
 	return
 }
@@ -8325,7 +8331,7 @@ func (s *ChestSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 
 // ChestCloseServerPacket ::  Reply to trying to interact with a locked or "broken" chest. The official client assumes a broken chest if the packet is under 2 bytes in length.
 type ChestCloseServerPacket struct {
-	Key int // Sent if the player is trying to interact with a locked chest.
+	Key *int // Sent if the player is trying to interact with a locked chest.
 
 }
 
@@ -8342,8 +8348,11 @@ func (s *ChestCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// Key : field : short
-	if err = writer.AddShort(s.Key); err != nil {
-		return
+	if s.Key != nil {
+		if err = writer.AddShort(*s.Key); err != nil {
+			return
+		}
+
 	}
 
 	//  : dummy : string
@@ -8359,7 +8368,10 @@ func (s *ChestCloseServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
 	// Key : field : short
-	s.Key = reader.GetShort()
+	if reader.Remaining() > 0 {
+		s.Key = new(int)
+		*s.Key = reader.GetShort()
+	}
 	//  : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
@@ -9823,8 +9835,8 @@ type SpellTargetSelfServerPacket struct {
 	SpellId      int
 	SpellHealHp  int
 	HpPercentage int
-	Hp           int // The official client reads this if the packet is larger than 12 bytes.
-	Tp           int // The official client reads this if the packet is larger than 12 bytes.
+	Hp           *int // The official client reads this if the packet is larger than 12 bytes.
+	Tp           *int // The official client reads this if the packet is larger than 12 bytes.
 }
 
 func (s SpellTargetSelfServerPacket) Family() net.PacketFamily {
@@ -9860,13 +9872,19 @@ func (s *SpellTargetSelfServerPacket) Serialize(writer *data.EoWriter) (err erro
 	}
 
 	// Hp : field : short
-	if err = writer.AddShort(s.Hp); err != nil {
-		return
+	if s.Hp != nil {
+		if err = writer.AddShort(*s.Hp); err != nil {
+			return
+		}
+
 	}
 
 	// Tp : field : short
-	if err = writer.AddShort(s.Tp); err != nil {
-		return
+	if s.Tp != nil {
+		if err = writer.AddShort(*s.Tp); err != nil {
+			return
+		}
+
 	}
 
 	return
@@ -9885,9 +9903,15 @@ func (s *SpellTargetSelfServerPacket) Deserialize(reader *data.EoReader) (err er
 	// HpPercentage : field : char
 	s.HpPercentage = reader.GetChar()
 	// Hp : field : short
-	s.Hp = reader.GetShort()
+	if reader.Remaining() > 0 {
+		s.Hp = new(int)
+		*s.Hp = reader.GetShort()
+	}
 	// Tp : field : short
-	s.Tp = reader.GetShort()
+	if reader.Remaining() > 0 {
+		s.Tp = new(int)
+		*s.Tp = reader.GetShort()
+	}
 
 	return
 }
@@ -10143,7 +10167,7 @@ type SpellTargetOtherServerPacket struct {
 	SpellId         int
 	SpellHealHp     int
 	HpPercentage    int
-	Hp              int
+	Hp              *int
 }
 
 func (s SpellTargetOtherServerPacket) Family() net.PacketFamily {
@@ -10189,8 +10213,11 @@ func (s *SpellTargetOtherServerPacket) Serialize(writer *data.EoWriter) (err err
 	}
 
 	// Hp : field : short
-	if err = writer.AddShort(s.Hp); err != nil {
-		return
+	if s.Hp != nil {
+		if err = writer.AddShort(*s.Hp); err != nil {
+			return
+		}
+
 	}
 
 	return
@@ -10213,7 +10240,10 @@ func (s *SpellTargetOtherServerPacket) Deserialize(reader *data.EoReader) (err e
 	// HpPercentage : field : char
 	s.HpPercentage = reader.GetChar()
 	// Hp : field : short
-	s.Hp = reader.GetShort()
+	if reader.Remaining() > 0 {
+		s.Hp = new(int)
+		*s.Hp = reader.GetShort()
+	}
 
 	return
 }
@@ -10593,7 +10623,7 @@ type NpcReplyServerPacket struct {
 	NpcIndex            int
 	Damage              int
 	HpPercentage        int
-	KillStealProtection NpcKillStealProtectionState
+	KillStealProtection *NpcKillStealProtectionState
 }
 
 func (s NpcReplyServerPacket) Family() net.PacketFamily {
@@ -10634,8 +10664,11 @@ func (s *NpcReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	}
 
 	// KillStealProtection : field : NpcKillStealProtectionState
-	if err = writer.AddChar(int(s.KillStealProtection)); err != nil {
-		return
+	if s.KillStealProtection != nil {
+		if err = writer.AddChar(int(*s.KillStealProtection)); err != nil {
+			return
+		}
+
 	}
 
 	return
@@ -10656,7 +10689,10 @@ func (s *NpcReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	// HpPercentage : field : short
 	s.HpPercentage = reader.GetShort()
 	// KillStealProtection : field : NpcKillStealProtectionState
-	s.KillStealProtection = NpcKillStealProtectionState(reader.GetChar())
+	if reader.Remaining() > 0 {
+		s.KillStealProtection = new(NpcKillStealProtectionState)
+		*s.KillStealProtection = NpcKillStealProtectionState(reader.GetChar())
+	}
 
 	return
 }
@@ -10670,7 +10706,7 @@ type CastReplyServerPacket struct {
 	Damage              int
 	HpPercentage        int
 	CasterTp            int
-	KillStealProtection NpcKillStealProtectionState
+	KillStealProtection *NpcKillStealProtectionState
 }
 
 func (s CastReplyServerPacket) Family() net.PacketFamily {
@@ -10721,8 +10757,11 @@ func (s *CastReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	}
 
 	// KillStealProtection : field : NpcKillStealProtectionState
-	if err = writer.AddChar(int(s.KillStealProtection)); err != nil {
-		return
+	if s.KillStealProtection != nil {
+		if err = writer.AddChar(int(*s.KillStealProtection)); err != nil {
+			return
+		}
+
 	}
 
 	return
@@ -10747,7 +10786,10 @@ func (s *CastReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	// CasterTp : field : short
 	s.CasterTp = reader.GetShort()
 	// KillStealProtection : field : NpcKillStealProtectionState
-	s.KillStealProtection = NpcKillStealProtectionState(reader.GetChar())
+	if reader.Remaining() > 0 {
+		s.KillStealProtection = new(NpcKillStealProtectionState)
+		*s.KillStealProtection = NpcKillStealProtectionState(reader.GetChar())
+	}
 
 	return
 }
@@ -10755,7 +10797,7 @@ func (s *CastReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 // NpcSpecServerPacket :: Nearby NPC killed by player.
 type NpcSpecServerPacket struct {
 	NpcKilledData NpcKilledData
-	Experience    int
+	Experience    *int
 }
 
 func (s NpcSpecServerPacket) Family() net.PacketFamily {
@@ -10775,8 +10817,11 @@ func (s *NpcSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// Experience : field : int
-	if err = writer.AddInt(s.Experience); err != nil {
-		return
+	if s.Experience != nil {
+		if err = writer.AddInt(*s.Experience); err != nil {
+			return
+		}
+
 	}
 
 	return
@@ -10791,7 +10836,10 @@ func (s *NpcSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// Experience : field : int
-	s.Experience = reader.GetInt()
+	if reader.Remaining() > 0 {
+		s.Experience = new(int)
+		*s.Experience = reader.GetInt()
+	}
 
 	return
 }
@@ -10854,7 +10902,7 @@ type CastSpecServerPacket struct {
 	SpellId       int
 	NpcKilledData NpcKilledData
 	CasterTp      int
-	Experience    int
+	Experience    *int
 }
 
 func (s CastSpecServerPacket) Family() net.PacketFamily {
@@ -10884,8 +10932,11 @@ func (s *CastSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	}
 
 	// Experience : field : int
-	if err = writer.AddInt(s.Experience); err != nil {
-		return
+	if s.Experience != nil {
+		if err = writer.AddInt(*s.Experience); err != nil {
+			return
+		}
+
 	}
 
 	return
@@ -10904,7 +10955,10 @@ func (s *CastSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	// CasterTp : field : short
 	s.CasterTp = reader.GetShort()
 	// Experience : field : int
-	s.Experience = reader.GetInt()
+	if reader.Remaining() > 0 {
+		s.Experience = new(int)
+		*s.Experience = reader.GetInt()
+	}
 
 	return
 }
@@ -11018,8 +11072,8 @@ type NpcPlayerServerPacket struct {
 	Positions []NpcUpdatePosition
 	Attacks   []NpcUpdateAttack
 	Chats     []NpcUpdateChat
-	Hp        int
-	Tp        int
+	Hp        *int
+	Tp        *int
 }
 
 func (s NpcPlayerServerPacket) Family() net.PacketFamily {
@@ -11060,13 +11114,19 @@ func (s *NpcPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 
 	writer.AddByte(0xFF)
 	// Hp : field : short
-	if err = writer.AddShort(s.Hp); err != nil {
-		return
+	if s.Hp != nil {
+		if err = writer.AddShort(*s.Hp); err != nil {
+			return
+		}
+
 	}
 
 	// Tp : field : short
-	if err = writer.AddShort(s.Tp); err != nil {
-		return
+	if s.Tp != nil {
+		if err = writer.AddShort(*s.Tp); err != nil {
+			return
+		}
+
 	}
 
 	writer.SanitizeStrings = false
@@ -11112,9 +11172,15 @@ func (s *NpcPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// Hp : field : short
-	s.Hp = reader.GetShort()
+	if reader.Remaining() > 0 {
+		s.Hp = new(int)
+		*s.Hp = reader.GetShort()
+	}
 	// Tp : field : short
-	s.Tp = reader.GetShort()
+	if reader.Remaining() > 0 {
+		s.Tp = new(int)
+		*s.Tp = reader.GetShort()
+	}
 	reader.SetIsChunked(false)
 
 	return
@@ -12167,9 +12233,9 @@ func (s *RecoverListServerPacket) Deserialize(reader *data.EoReader) (err error)
 type RecoverReplyServerPacket struct {
 	Experience  int
 	Karma       int
-	LevelUp     int //  A value greater than 0 is "new level" and indicates the player leveled up. The official client reads this if the packet is larger than 6 bytes.
-	StatPoints  int // The official client reads this if the player leveled up.
-	SkillPoints int // The official client reads this if the player leveled up.
+	LevelUp     *int //  A value greater than 0 is "new level" and indicates the player leveled up. The official client reads this if the packet is larger than 6 bytes.
+	StatPoints  *int // The official client reads this if the player leveled up.
+	SkillPoints *int // The official client reads this if the player leveled up.
 }
 
 func (s RecoverReplyServerPacket) Family() net.PacketFamily {
@@ -12195,18 +12261,27 @@ func (s *RecoverReplyServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	}
 
 	// LevelUp : field : char
-	if err = writer.AddChar(s.LevelUp); err != nil {
-		return
+	if s.LevelUp != nil {
+		if err = writer.AddChar(*s.LevelUp); err != nil {
+			return
+		}
+
 	}
 
 	// StatPoints : field : short
-	if err = writer.AddShort(s.StatPoints); err != nil {
-		return
+	if s.StatPoints != nil {
+		if err = writer.AddShort(*s.StatPoints); err != nil {
+			return
+		}
+
 	}
 
 	// SkillPoints : field : short
-	if err = writer.AddShort(s.SkillPoints); err != nil {
-		return
+	if s.SkillPoints != nil {
+		if err = writer.AddShort(*s.SkillPoints); err != nil {
+			return
+		}
+
 	}
 
 	return
@@ -12221,11 +12296,20 @@ func (s *RecoverReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 	// Karma : field : short
 	s.Karma = reader.GetShort()
 	// LevelUp : field : char
-	s.LevelUp = reader.GetChar()
+	if reader.Remaining() > 0 {
+		s.LevelUp = new(int)
+		*s.LevelUp = reader.GetChar()
+	}
 	// StatPoints : field : short
-	s.StatPoints = reader.GetShort()
+	if reader.Remaining() > 0 {
+		s.StatPoints = new(int)
+		*s.StatPoints = reader.GetShort()
+	}
 	// SkillPoints : field : short
-	s.SkillPoints = reader.GetShort()
+	if reader.Remaining() > 0 {
+		s.SkillPoints = new(int)
+		*s.SkillPoints = reader.GetShort()
+	}
 
 	return
 }

--- a/pkg/eolib/protocol/net/server/packets_generated.go
+++ b/pkg/eolib/protocol/net/server/packets_generated.go
@@ -65,32 +65,26 @@ func (s *InitInitReplyCodeDataOk) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddByte(s.Seq1); err != nil {
 		return
 	}
-
 	// Seq2 : field : byte
 	if err = writer.AddByte(s.Seq2); err != nil {
 		return
 	}
-
 	// ServerEncryptionMultiple : field : byte
 	if err = writer.AddByte(s.ServerEncryptionMultiple); err != nil {
 		return
 	}
-
 	// ClientEncryptionMultiple : field : byte
 	if err = writer.AddByte(s.ClientEncryptionMultiple); err != nil {
 		return
 	}
-
 	// PlayerId : field : short
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// ChallengeResponse : field : three
 	if err = writer.AddThree(s.ChallengeResponse); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -136,7 +130,6 @@ func (s *InitInitBanTypeData0) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddByte(s.MinutesRemaining); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -162,7 +155,6 @@ func (s *InitInitBanTypeDataTemporary) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddByte(s.MinutesRemaining); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -184,7 +176,6 @@ func (s *InitInitReplyCodeDataBanned) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddByte(int(s.BanType)); err != nil {
 		return
 	}
-
 	switch s.BanType {
 	case 0:
 		switch s.BanTypeData.(type) {
@@ -499,7 +490,6 @@ func (s *InitInitServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddByte(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	switch s.ReplyCode {
 	case InitReply_OutOfDate:
 		switch s.ReplyCodeData.(type) {
@@ -1051,12 +1041,10 @@ func (s *ConnectionPlayerServerPacket) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddShort(s.Seq1); err != nil {
 		return
 	}
-
 	// Seq2 : field : char
 	if err = writer.AddChar(s.Seq2); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1093,7 +1081,6 @@ func (s *AccountReplyReplyCodeDataExists) Serialize(writer *data.EoWriter) (err 
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1120,7 +1107,6 @@ func (s *AccountReplyReplyCodeDataNotApproved) Serialize(writer *data.EoWriter) 
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1147,7 +1133,6 @@ func (s *AccountReplyReplyCodeDataCreated) Serialize(writer *data.EoWriter) (err
 	if err = writer.AddString("GO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1174,7 +1159,6 @@ func (s *AccountReplyReplyCodeDataChangeFailed) Serialize(writer *data.EoWriter)
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1201,7 +1185,6 @@ func (s *AccountReplyReplyCodeDataChanged) Serialize(writer *data.EoWriter) (err
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1228,7 +1211,6 @@ func (s *AccountReplyReplyCodeDataRequestDenied) Serialize(writer *data.EoWriter
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1257,12 +1239,10 @@ func (s *AccountReplyReplyCodeDataDefault) Serialize(writer *data.EoWriter) (err
 	if err = writer.AddChar(s.SequenceStart); err != nil {
 		return
 	}
-
 	//  : field : string
 	if err = writer.AddString("OK"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1296,7 +1276,6 @@ func (s *AccountReplyServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	switch s.ReplyCode {
 	case AccountReply_Exists:
 		switch s.ReplyCodeData.(type) {
@@ -1440,7 +1419,6 @@ func (s *CharacterReplyReplyCodeDataExists) Serialize(writer *data.EoWriter) (er
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1467,7 +1445,6 @@ func (s *CharacterReplyReplyCodeDataFull) Serialize(writer *data.EoWriter) (err 
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1494,7 +1471,6 @@ func (s *CharacterReplyReplyCodeDataFull3) Serialize(writer *data.EoWriter) (err
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1521,7 +1497,6 @@ func (s *CharacterReplyReplyCodeDataNotApproved) Serialize(writer *data.EoWriter
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1551,12 +1526,10 @@ func (s *CharacterReplyReplyCodeDataOk) Serialize(writer *data.EoWriter) (err er
 	if err = writer.AddChar(s.CharactersCount); err != nil {
 		return
 	}
-
 	//  : field : char
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Characters : array : CharacterSelectionListEntry
 	for ndx := 0; ndx < s.CharactersCount; ndx++ {
@@ -1604,7 +1577,6 @@ func (s *CharacterReplyReplyCodeDataDeleted) Serialize(writer *data.EoWriter) (e
 	if err = writer.AddChar(s.CharactersCount); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Characters : array : CharacterSelectionListEntry
 	for ndx := 0; ndx < s.CharactersCount; ndx++ {
@@ -1649,7 +1621,6 @@ func (s *CharacterReplyReplyCodeDataDefault) Serialize(writer *data.EoWriter) (e
 	if err = writer.AddString("OK"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1682,7 +1653,6 @@ func (s *CharacterReplyServerPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddShort(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	switch s.ReplyCode {
 	case CharacterReply_Exists:
 		switch s.ReplyCodeData.(type) {
@@ -1830,12 +1800,10 @@ func (s *CharacterPlayerServerPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// CharacterId : field : int
 	if err = writer.AddInt(s.CharacterId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1872,7 +1840,6 @@ func (s *LoginReplyReplyCodeDataWrongUser) Serialize(writer *data.EoWriter) (err
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1899,7 +1866,6 @@ func (s *LoginReplyReplyCodeDataWrongUserPassword) Serialize(writer *data.EoWrit
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1929,12 +1895,10 @@ func (s *LoginReplyReplyCodeDataOk) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddChar(s.CharactersCount); err != nil {
 		return
 	}
-
 	//  : field : char
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Characters : array : CharacterSelectionListEntry
 	for ndx := 0; ndx < s.CharactersCount; ndx++ {
@@ -1980,7 +1944,6 @@ func (s *LoginReplyReplyCodeDataBanned) Serialize(writer *data.EoWriter) (err er
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2007,7 +1970,6 @@ func (s *LoginReplyReplyCodeDataLoggedIn) Serialize(writer *data.EoWriter) (err 
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2034,7 +1996,6 @@ func (s *LoginReplyReplyCodeDataBusy) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddString("NO"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2067,7 +2028,6 @@ func (s *LoginReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	switch s.ReplyCode {
 	case LoginReply_WrongUser:
 		switch s.ReplyCodeData.(type) {
@@ -2227,136 +2187,113 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Serialize(writer *data.EoWr
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// CharacterId : field : int
 	if err = writer.AddInt(s.CharacterId); err != nil {
 		return
 	}
-
 	// MapId : field : short
 	if err = writer.AddShort(s.MapId); err != nil {
 		return
 	}
-
 	// MapRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.MapRid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// MapFileSize : field : three
 	if err = writer.AddThree(s.MapFileSize); err != nil {
 		return
 	}
-
 	// EifRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.EifRid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// EifLength : field : short
 	if err = writer.AddShort(s.EifLength); err != nil {
 		return
 	}
-
 	// EnfRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.EnfRid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// EnfLength : field : short
 	if err = writer.AddShort(s.EnfLength); err != nil {
 		return
 	}
-
 	// EsfRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.EsfRid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// EsfLength : field : short
 	if err = writer.AddShort(s.EsfLength); err != nil {
 		return
 	}
-
 	// EcfRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.EcfRid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// EcfLength : field : short
 	if err = writer.AddShort(s.EcfLength); err != nil {
 		return
 	}
-
 	// Name : field : string
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Title : field : string
 	if err = writer.AddString(s.Title); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildName : field : string
 	if err = writer.AddString(s.GuildName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildRankName : field : string
 	if err = writer.AddString(s.GuildRankName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// ClassId : field : char
 	if err = writer.AddChar(s.ClassId); err != nil {
 		return
 	}
-
 	// GuildTag : field : string
 	if err = writer.AddFixedString(s.GuildTag, 3); err != nil {
 		return
 	}
-
 	// Admin : field : AdminLevel
 	if err = writer.AddChar(int(s.Admin)); err != nil {
 		return
 	}
-
 	// Level : field : char
 	if err = writer.AddChar(s.Level); err != nil {
 		return
 	}
-
 	// Experience : field : int
 	if err = writer.AddInt(s.Experience); err != nil {
 		return
 	}
-
 	// Usage : field : int
 	if err = writer.AddInt(s.Usage); err != nil {
 		return
 	}
-
 	// Stats : field : CharacterStatsWelcome
 	if err = s.Stats.Serialize(writer); err != nil {
 		return
@@ -2369,7 +2306,6 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Serialize(writer *data.EoWr
 	if err = writer.AddChar(s.GuildRank); err != nil {
 		return
 	}
-
 	// Settings : field : ServerSettings
 	if err = s.Settings.Serialize(writer); err != nil {
 		return
@@ -2378,7 +2314,6 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Serialize(writer *data.EoWr
 	if err = writer.AddChar(int(s.LoginMessageCode)); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	return
 }
@@ -2516,7 +2451,6 @@ func (s *WelcomeReplyWelcomeCodeDataEnterGame) Serialize(writer *data.EoWriter) 
 		if err = writer.AddString(s.News[ndx]); err != nil {
 			return
 		}
-
 		writer.AddByte(0xFF)
 	}
 
@@ -2612,7 +2546,6 @@ func (s *WelcomeReplyServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(int(s.WelcomeCode)); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = true
 	switch s.WelcomeCode {
 	case WelcomeCode_SelectCharacter:
@@ -2687,13 +2620,11 @@ func (s *AdminInteractReplyMessageTypeDataMessage) Serialize(writer *data.EoWrit
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	return
 }
@@ -2736,19 +2667,16 @@ func (s *AdminInteractReplyMessageTypeDataReport) Serialize(writer *data.EoWrite
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// ReporteeName : field : string
 	if err = writer.AddString(s.ReporteeName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	return
 }
@@ -2802,7 +2730,6 @@ func (s *AdminInteractReplyServerPacket) Serialize(writer *data.EoWriter) (err e
 	if err = writer.AddChar(int(s.MessageType)); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	switch s.MessageType {
 	case AdminMessage_Message:
@@ -2878,7 +2805,6 @@ func (s *AdminInteractRemoveServerPacket) Serialize(writer *data.EoWriter) (err 
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2913,7 +2839,6 @@ func (s *AdminInteractAgreeServerPacket) Serialize(writer *data.EoWriter) (err e
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2953,19 +2878,16 @@ func (s *AdminInteractListServerPacket) Serialize(writer *data.EoWriter) (err er
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Usage : field : int
 	if err = writer.AddInt(s.Usage); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GoldBank : field : int
 	if err = writer.AddInt(s.GoldBank); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Inventory : array : Item
 	for ndx := 0; ndx < len(s.Inventory); ndx++ {
@@ -3062,30 +2984,25 @@ func (s *AdminInteractTellServerPacket) Serialize(writer *data.EoWriter) (err er
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Usage : field : int
 	if err = writer.AddInt(s.Usage); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.AddByte(0xFF)
 	// Exp : field : int
 	if err = writer.AddInt(s.Exp); err != nil {
 		return
 	}
-
 	// Level : field : char
 	if err = writer.AddChar(s.Level); err != nil {
 		return
 	}
-
 	// MapId : field : short
 	if err = writer.AddShort(s.MapId); err != nil {
 		return
 	}
-
 	// MapCoords : field : BigCoords
 	if err = s.MapCoords.Serialize(writer); err != nil {
 		return
@@ -3169,13 +3086,11 @@ func (s *TalkRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -3225,12 +3140,10 @@ func (s *TalkOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3271,13 +3184,11 @@ func (s *TalkMsgServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -3328,13 +3239,11 @@ func (s *TalkTellServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -3384,12 +3293,10 @@ func (s *TalkPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3429,12 +3336,10 @@ func (s *TalkReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	// Name : field : string
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3475,13 +3380,11 @@ func (s *TalkAdminServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -3532,13 +3435,11 @@ func (s *TalkAnnounceServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -3587,7 +3488,6 @@ func (s *TalkServerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3675,7 +3575,6 @@ func (s *MessageOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3711,7 +3610,6 @@ func (s *MessageCloseServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddString("r"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3750,7 +3648,6 @@ func (s *MessageAcceptServerPacket) Serialize(writer *data.EoWriter) (err error)
 		if err = writer.AddString(s.Messages[ndx]); err != nil {
 			return
 		}
-
 		writer.AddByte(0xFF)
 	}
 
@@ -3800,7 +3697,6 @@ func (s *TalkSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.AdminName); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3838,12 +3734,10 @@ func (s *AttackPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Direction : field : Direction
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3879,7 +3773,6 @@ func (s *AttackErrorServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddByte(255); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3919,27 +3812,22 @@ func (s *AvatarReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// VictimId : field : short
 	if err = writer.AddShort(s.VictimId); err != nil {
 		return
 	}
-
 	// Damage : field : three
 	if err = writer.AddThree(s.Damage); err != nil {
 		return
 	}
-
 	// Direction : field : Direction
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	// Dead : field : bool
 	if s.Dead {
 		err = writer.AddChar(1)
@@ -4000,7 +3888,6 @@ func (s *ChairPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -4009,7 +3896,6 @@ func (s *ChairPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4052,7 +3938,6 @@ func (s *ChairReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -4061,7 +3946,6 @@ func (s *ChairReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4103,7 +3987,6 @@ func (s *ChairCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -4147,7 +4030,6 @@ func (s *ChairRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -4192,7 +4074,6 @@ func (s *SitPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -4201,12 +4082,10 @@ func (s *SitPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	//  : field : char
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4250,7 +4129,6 @@ func (s *SitCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -4294,7 +4172,6 @@ func (s *SitRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -4339,7 +4216,6 @@ func (s *SitReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -4348,12 +4224,10 @@ func (s *SitReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	//  : field : char
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4397,12 +4271,10 @@ func (s *EmotePlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Emote : field : Emote
 	if err = writer.AddChar(int(s.Emote)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4440,12 +4312,10 @@ func (s *EffectPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// EffectId : field : three
 	if err = writer.AddThree(s.EffectId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4483,12 +4353,10 @@ func (s *FacePlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Direction : field : Direction
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4526,15 +4394,12 @@ func (s *AvatarRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// WarpEffect : field : WarpEffect
 	if s.WarpEffect != nil {
 		if err = writer.AddChar(int(*s.WarpEffect)); err != nil {
 			return
 		}
-
 	}
-
 	return
 }
 
@@ -4610,7 +4475,6 @@ func (s *PlayersRemoveServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4682,7 +4546,6 @@ func (s *NpcAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.NpcsCount); err != nil {
 		return
 	}
-
 	// Npcs : array : NpcMapInfo
 	for ndx := 0; ndx < s.NpcsCount; ndx++ {
 		if err = s.Npcs[ndx].Serialize(writer); err != nil {
@@ -4733,12 +4596,10 @@ func (s *WalkPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Direction : field : Direction
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -4787,7 +4648,6 @@ func (s *WalkReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddShort(s.PlayerIds[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	writer.AddByte(0xFF)
@@ -4796,7 +4656,6 @@ func (s *WalkReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddChar(s.NpcIndexes[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	writer.AddByte(0xFF)
@@ -4865,7 +4724,6 @@ func (s *WalkCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString("S"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4901,7 +4759,6 @@ func (s *WalkOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString("S"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4940,17 +4797,14 @@ func (s *BankOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.GoldBank); err != nil {
 		return
 	}
-
 	// SessionId : field : three
 	if err = writer.AddThree(s.SessionId); err != nil {
 		return
 	}
-
 	// LockerUpgrades : field : char
 	if err = writer.AddChar(s.LockerUpgrades); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -4990,12 +4844,10 @@ func (s *BankReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.GoldInventory); err != nil {
 		return
 	}
-
 	// GoldBank : field : int
 	if err = writer.AddInt(s.GoldBank); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5033,7 +4885,6 @@ func (s *BarberAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	// Change : field : AvatarChange
 	if err = s.Change.Serialize(writer); err != nil {
 		return
@@ -5076,7 +4927,6 @@ func (s *BarberOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5283,12 +5133,10 @@ func (s *LockerBuyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	// LockerUpgrades : field : char
 	if err = writer.AddChar(s.LockerUpgrades); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5325,7 +5173,6 @@ func (s *LockerSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.LockerMaxItems); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5360,7 +5207,6 @@ func (s *CitizenReplyServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddChar(s.QuestionsWrong); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5395,7 +5241,6 @@ func (s *CitizenRemoveServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddChar(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5434,17 +5279,14 @@ func (s *CitizenOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddThree(s.BehaviorId); err != nil {
 		return
 	}
-
 	// CurrentHomeId : field : char
 	if err = writer.AddChar(s.CurrentHomeId); err != nil {
 		return
 	}
-
 	// SessionId : field : short
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Questions : array : string
 	for ndx := 0; ndx < 3; ndx++ {
@@ -5455,7 +5297,6 @@ func (s *CitizenOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddString(s.Questions[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	writer.SanitizeStrings = false
@@ -5515,7 +5356,6 @@ func (s *CitizenRequestServerPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddInt(s.Cost); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5550,7 +5390,6 @@ func (s *CitizenAcceptServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5587,7 +5426,6 @@ func (s *ShopCreateServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.CraftItemId); err != nil {
 		return
 	}
-
 	// Weight : field : Weight
 	if err = s.Weight.Serialize(writer); err != nil {
 		return
@@ -5646,7 +5484,6 @@ func (s *ShopBuyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	// BoughtItem : field : Item
 	if err = s.BoughtItem.Serialize(writer); err != nil {
 		return
@@ -5703,7 +5540,6 @@ func (s *ShopSellServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	// Weight : field : Weight
 	if err = s.Weight.Serialize(writer); err != nil {
 		return
@@ -5754,12 +5590,10 @@ func (s *ShopOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// ShopName : field : string
 	if err = writer.AddString(s.ShopName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// TradeItems : array : ShopTradeItem
 	for ndx := 0; ndx < len(s.TradeItems); ndx++ {
@@ -5847,12 +5681,10 @@ func (s *StatSkillOpenServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// ShopName : field : string
 	if err = writer.AddString(s.ShopName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Skills : array : SkillLearn
 	for ndx := 0; ndx < len(s.Skills); ndx++ {
@@ -5915,7 +5747,6 @@ func (s *StatSkillReplyReplyCodeDataWrongClass) Serialize(writer *data.EoWriter)
 	if err = writer.AddChar(s.ClassId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -5945,7 +5776,6 @@ func (s *StatSkillReplyServerPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddShort(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	switch s.ReplyCode {
 	case SkillMasterReply_WrongClass:
 		switch s.ReplyCodeData.(type) {
@@ -6000,12 +5830,10 @@ func (s *StatSkillTakeServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// GoldAmount : field : int
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6042,7 +5870,6 @@ func (s *StatSkillRemoveServerPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6078,7 +5905,6 @@ func (s *StatSkillPlayerServerPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddShort(s.StatPoints); err != nil {
 		return
 	}
-
 	// Stats : field : CharacterStatsUpdate
 	if err = s.Stats.Serialize(writer); err != nil {
 		return
@@ -6122,7 +5948,6 @@ func (s *StatSkillAcceptServerPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddShort(s.SkillPoints); err != nil {
 		return
 	}
-
 	// Spell : field : Spell
 	if err = s.Spell.Serialize(writer); err != nil {
 		return
@@ -6206,17 +6031,14 @@ func (s *ItemReplyItemTypeDataHeal) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddInt(s.HpGain); err != nil {
 		return
 	}
-
 	// Hp : field : short
 	if err = writer.AddShort(s.Hp); err != nil {
 		return
 	}
-
 	// Tp : field : short
 	if err = writer.AddShort(s.Tp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6246,7 +6068,6 @@ func (s *ItemReplyItemTypeDataHairDye) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddChar(s.HairColor); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6272,7 +6093,6 @@ func (s *ItemReplyItemTypeDataEffectPotion) Serialize(writer *data.EoWriter) (er
 	if err = writer.AddShort(s.EffectId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6331,37 +6151,30 @@ func (s *ItemReplyItemTypeDataExpReward) Serialize(writer *data.EoWriter) (err e
 	if err = writer.AddInt(s.Experience); err != nil {
 		return
 	}
-
 	// LevelUp : field : char
 	if err = writer.AddChar(s.LevelUp); err != nil {
 		return
 	}
-
 	// StatPoints : field : short
 	if err = writer.AddShort(s.StatPoints); err != nil {
 		return
 	}
-
 	// SkillPoints : field : short
 	if err = writer.AddShort(s.SkillPoints); err != nil {
 		return
 	}
-
 	// MaxHp : field : short
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	// MaxTp : field : short
 	if err = writer.AddShort(s.MaxTp); err != nil {
 		return
 	}
-
 	// MaxSp : field : short
 	if err = writer.AddShort(s.MaxSp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6403,7 +6216,6 @@ func (s *ItemReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.ItemType)); err != nil {
 		return
 	}
-
 	// UsedItem : field : Item
 	if err = s.UsedItem.Serialize(writer); err != nil {
 		return
@@ -6541,12 +6353,10 @@ func (s *ItemDropServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.RemainingAmount); err != nil {
 		return
 	}
-
 	// ItemIndex : field : short
 	if err = writer.AddShort(s.ItemIndex); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -6606,17 +6416,14 @@ func (s *ItemAddServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	// ItemIndex : field : short
 	if err = writer.AddShort(s.ItemIndex); err != nil {
 		return
 	}
-
 	// ItemAmount : field : three
 	if err = writer.AddThree(s.ItemAmount); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -6663,7 +6470,6 @@ func (s *ItemRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.ItemIndex); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6704,7 +6510,6 @@ func (s *ItemJunkServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.RemainingAmount); err != nil {
 		return
 	}
-
 	// Weight : field : Weight
 	if err = s.Weight.Serialize(writer); err != nil {
 		return
@@ -6753,7 +6558,6 @@ func (s *ItemGetServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.TakenItemIndex); err != nil {
 		return
 	}
-
 	// TakenItem : field : ThreeItem
 	if err = s.TakenItem.Serialize(writer); err != nil {
 		return
@@ -6809,7 +6613,6 @@ func (s *ItemObtainServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.CurrentWeight); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6853,7 +6656,6 @@ func (s *ItemKickServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.CurrentWeight); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6892,7 +6694,6 @@ func (s *ItemAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6926,7 +6727,6 @@ func (s *ItemSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(2); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -6963,12 +6763,10 @@ func (s *BoardPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PostId); err != nil {
 		return
 	}
-
 	// PostBody : field : string
 	if err = writer.AddString(s.PostBody); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -7014,12 +6812,10 @@ func (s *BoardOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.BoardId); err != nil {
 		return
 	}
-
 	// PostsCount : length : char
 	if err = writer.AddChar(s.PostsCount); err != nil {
 		return
 	}
-
 	// Posts : array : BoardPostListing
 	for ndx := 0; ndx < s.PostsCount; ndx++ {
 		if err = s.Posts[ndx].Serialize(writer); err != nil {
@@ -7078,7 +6874,6 @@ func (s *JukeboxAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7112,7 +6907,6 @@ func (s *JukeboxReplyServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(1); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7148,12 +6942,10 @@ func (s *JukeboxOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.MapId); err != nil {
 		return
 	}
-
 	// JukeboxPlayer : field : string
 	if err = writer.AddString(s.JukeboxPlayer); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7195,22 +6987,18 @@ func (s *JukeboxMsgServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Direction : field : Direction
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	// InstrumentId : field : char
 	if err = writer.AddChar(s.InstrumentId); err != nil {
 		return
 	}
-
 	// NoteId : field : char
 	if err = writer.AddChar(s.NoteId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7251,7 +7039,6 @@ func (s *JukeboxPlayerServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddChar(s.MfxId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7286,7 +7073,6 @@ func (s *JukeboxUseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.TrackId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7326,14 +7112,12 @@ func (s *WarpRequestWarpTypeDataMapSwitch) Serialize(writer *data.EoWriter) (err
 		if err = writer.AddShort(s.MapRid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// MapFileSize : field : three
 	if err = writer.AddThree(s.MapFileSize); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7368,12 +7152,10 @@ func (s *WarpRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.WarpType)); err != nil {
 		return
 	}
-
 	// MapId : field : short
 	if err = writer.AddShort(s.MapId); err != nil {
 		return
 	}
-
 	switch s.WarpType {
 	case Warp_MapSwitch:
 		switch s.WarpTypeData.(type) {
@@ -7390,7 +7172,6 @@ func (s *WarpRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7439,12 +7220,10 @@ func (s *WarpAgreeWarpTypeDataMapSwitch) Serialize(writer *data.EoWriter) (err e
 	if err = writer.AddShort(s.MapId); err != nil {
 		return
 	}
-
 	// WarpEffect : field : WarpEffect
 	if err = writer.AddChar(int(s.WarpEffect)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7477,7 +7256,6 @@ func (s *WarpAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.WarpType)); err != nil {
 		return
 	}
-
 	switch s.WarpType {
 	case Warp_MapSwitch:
 		switch s.WarpTypeData.(type) {
@@ -7553,7 +7331,6 @@ func (s *PaperdollReplyServerPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddChar(int(s.Icon)); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -7599,7 +7376,6 @@ func (s *PaperdollPingServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddChar(s.ClassId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7641,12 +7417,10 @@ func (s *PaperdollRemoveServerPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	// SubLoc : field : char
 	if err = writer.AddChar(s.SubLoc); err != nil {
 		return
 	}
-
 	// Stats : field : CharacterStatsEquipmentChange
 	if err = s.Stats.Serialize(writer); err != nil {
 		return
@@ -7703,17 +7477,14 @@ func (s *PaperdollAgreeServerPacket) Serialize(writer *data.EoWriter) (err error
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	// RemainingAmount : field : three
 	if err = writer.AddThree(s.RemainingAmount); err != nil {
 		return
 	}
-
 	// SubLoc : field : char
 	if err = writer.AddChar(s.SubLoc); err != nil {
 		return
 	}
-
 	// Stats : field : CharacterStatsEquipmentChange
 	if err = s.Stats.Serialize(writer); err != nil {
 		return
@@ -7807,14 +7578,12 @@ func (s *BookReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Icon)); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// QuestNames : array : string
 	for ndx := 0; ndx < len(s.QuestNames); ndx++ {
 		if err = writer.AddString(s.QuestNames[ndx]); err != nil {
 			return
 		}
-
 		writer.AddByte(0xFF)
 	}
 
@@ -7872,7 +7641,6 @@ func (s *MessagePongServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(2); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7907,7 +7675,6 @@ func (s *PlayersPingServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7944,7 +7711,6 @@ func (s *PlayersPongServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -7981,7 +7747,6 @@ func (s *PlayersNet242ServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8022,7 +7787,6 @@ func (s *DoorOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8061,7 +7825,6 @@ func (s *DoorCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Key); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8150,12 +7913,10 @@ func (s *ChestReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.AddedItemId); err != nil {
 		return
 	}
-
 	// RemainingAmount : field : int
 	if err = writer.AddInt(s.RemainingAmount); err != nil {
 		return
 	}
-
 	// Weight : field : Weight
 	if err = s.Weight.Serialize(writer); err != nil {
 		return
@@ -8315,7 +8076,6 @@ func (s *ChestSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddByte(0); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8352,14 +8112,11 @@ func (s *ChestCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddShort(*s.Key); err != nil {
 			return
 		}
-
 	}
-
 	//  : dummy : string
 	if err = writer.AddString("N"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8439,17 +8196,14 @@ func (s *PartyRequestServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddChar(int(s.RequestType)); err != nil {
 		return
 	}
-
 	// InviterPlayerId : field : short
 	if err = writer.AddShort(s.InviterPlayerId); err != nil {
 		return
 	}
-
 	// PlayerName : field : string
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8491,7 +8245,6 @@ func (s *PartyReplyReplyCodeDataAlreadyInAnotherParty) Serialize(writer *data.Eo
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8519,7 +8272,6 @@ func (s *PartyReplyReplyCodeDataAlreadyInYourParty) Serialize(writer *data.EoWri
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8551,7 +8303,6 @@ func (s *PartyReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	switch s.ReplyCode {
 	case PartyReplyCode_AlreadyInAnotherParty:
 		switch s.ReplyCodeData.(type) {
@@ -8707,7 +8458,6 @@ func (s *PartyRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8741,7 +8491,6 @@ func (s *PartyCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddByte(255); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8828,12 +8577,10 @@ func (s *PartyAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8913,7 +8660,6 @@ func (s *GuildReplyReplyCodeDataCreateAdd) Serialize(writer *data.EoWriter) (err
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8941,7 +8687,6 @@ func (s *GuildReplyReplyCodeDataCreateAddConfirm) Serialize(writer *data.EoWrite
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -8970,12 +8715,10 @@ func (s *GuildReplyReplyCodeDataJoinRequest) Serialize(writer *data.EoWriter) (e
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Name : field : string
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -9009,7 +8752,6 @@ func (s *GuildReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	switch s.ReplyCode {
 	case GuildReply_CreateAdd:
 		switch s.ReplyCodeData.(type) {
@@ -9094,12 +8836,10 @@ func (s *GuildRequestServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// GuildIdentity : field : string
 	if err = writer.AddString(s.GuildIdentity); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -9143,31 +8883,26 @@ func (s *GuildCreateServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.LeaderPlayerId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildTag : field : string
 	if err = writer.AddString(s.GuildTag); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildName : field : string
 	if err = writer.AddString(s.GuildName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// RankName : field : string
 	if err = writer.AddString(s.RankName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GoldAmount : field : int
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -9234,7 +8969,6 @@ func (s *GuildTakeServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Description); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -9273,7 +9007,6 @@ func (s *GuildRankServerPacket) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddString(s.Ranks[ndx]); err != nil {
 			return
 		}
-
 		writer.AddByte(0xFF)
 	}
 
@@ -9323,7 +9056,6 @@ func (s *GuildSellServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -9358,7 +9090,6 @@ func (s *GuildBuyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -9393,7 +9124,6 @@ func (s *GuildOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddThree(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -9430,7 +9160,6 @@ func (s *GuildTellServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.MembersCount); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Members : array : GuildMember
 	for ndx := 0; ndx < s.MembersCount; ndx++ {
@@ -9499,38 +9228,32 @@ func (s *GuildReportServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Tag : field : string
 	if err = writer.AddString(s.Tag); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// CreateDate : field : string
 	if err = writer.AddString(s.CreateDate); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Description : field : string
 	if err = writer.AddString(s.Description); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Wealth : field : string
 	if err = writer.AddString(s.Wealth); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Ranks : array : string
 	for ndx := 0; ndx < 9; ndx++ {
 		if err = writer.AddString(s.Ranks[ndx]); err != nil {
 			return
 		}
-
 		writer.AddByte(0xFF)
 	}
 
@@ -9538,7 +9261,6 @@ func (s *GuildReportServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.StaffCount); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Staff : array : GuildStaff
 	for ndx := 0; ndx < s.StaffCount; ndx++ {
@@ -9654,25 +9376,21 @@ func (s *GuildAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.RecruiterId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildTag : field : string
 	if err = writer.AddString(s.GuildTag); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildName : field : string
 	if err = writer.AddString(s.GuildName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// RankName : field : string
 	if err = writer.AddString(s.RankName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -9738,7 +9456,6 @@ func (s *GuildAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Rank); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -9772,7 +9489,6 @@ func (s *GuildKickServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddByte(255); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -9808,12 +9524,10 @@ func (s *SpellRequestServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// SpellId : field : short
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -9855,38 +9569,30 @@ func (s *SpellTargetSelfServerPacket) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// SpellId : field : short
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// SpellHealHp : field : int
 	if err = writer.AddInt(s.SpellHealHp); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	// Hp : field : short
 	if s.Hp != nil {
 		if err = writer.AddShort(*s.Hp); err != nil {
 			return
 		}
-
 	}
-
 	// Tp : field : short
 	if s.Tp != nil {
 		if err = writer.AddShort(*s.Tp); err != nil {
 			return
 		}
-
 	}
-
 	return
 }
 
@@ -9938,12 +9644,10 @@ func (s *SpellPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Direction : field : Direction
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -9979,7 +9683,6 @@ func (s *SpellErrorServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddByte(255); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -10020,27 +9723,22 @@ func (s *AvatarAdminServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.CasterId); err != nil {
 		return
 	}
-
 	// VictimId : field : short
 	if err = writer.AddShort(s.VictimId); err != nil {
 		return
 	}
-
 	// CasterDirection : field : Direction
 	if err = writer.AddChar(int(s.CasterDirection)); err != nil {
 		return
 	}
-
 	// Damage : field : three
 	if err = writer.AddThree(s.Damage); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	// VictimDied : field : bool
 	if s.VictimDied {
 		err = writer.AddChar(1)
@@ -10055,7 +9753,6 @@ func (s *AvatarAdminServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -10110,22 +9807,18 @@ func (s *SpellTargetGroupServerPacket) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// CasterId : field : short
 	if err = writer.AddShort(s.CasterId); err != nil {
 		return
 	}
-
 	// CasterTp : field : short
 	if err = writer.AddShort(s.CasterTp); err != nil {
 		return
 	}
-
 	// SpellHealHp : field : short
 	if err = writer.AddShort(s.SpellHealHp); err != nil {
 		return
 	}
-
 	// Players : array : GroupHealTargetPlayer
 	for ndx := 0; ndx < len(s.Players); ndx++ {
 		if err = s.Players[ndx].Serialize(writer); err != nil {
@@ -10186,40 +9879,32 @@ func (s *SpellTargetOtherServerPacket) Serialize(writer *data.EoWriter) (err err
 	if err = writer.AddShort(s.VictimId); err != nil {
 		return
 	}
-
 	// CasterId : field : short
 	if err = writer.AddShort(s.CasterId); err != nil {
 		return
 	}
-
 	// CasterDirection : field : Direction
 	if err = writer.AddChar(int(s.CasterDirection)); err != nil {
 		return
 	}
-
 	// SpellId : field : short
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// SpellHealHp : field : int
 	if err = writer.AddInt(s.SpellHealHp); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	// Hp : field : short
 	if s.Hp != nil {
 		if err = writer.AddShort(*s.Hp); err != nil {
 			return
 		}
-
 	}
-
 	return
 }
 
@@ -10270,17 +9955,14 @@ func (s *TradeRequestServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddChar(138); err != nil {
 		return
 	}
-
 	// PartnerPlayerId : field : short
 	if err = writer.AddShort(s.PartnerPlayerId); err != nil {
 		return
 	}
-
 	// PartnerPlayerName : field : string
 	if err = writer.AddString(s.PartnerPlayerName); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -10325,23 +10007,19 @@ func (s *TradeOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PartnerPlayerId); err != nil {
 		return
 	}
-
 	// PartnerPlayerName : field : string
 	if err = writer.AddString(s.PartnerPlayerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// YourPlayerId : field : short
 	if err = writer.AddShort(s.YourPlayerId); err != nil {
 		return
 	}
-
 	// YourPlayerName : field : string
 	if err = writer.AddString(s.YourPlayerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -10551,7 +10229,6 @@ func (s *TradeAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PartnerPlayerId); err != nil {
 		return
 	}
-
 	// Agree : field : bool
 	if s.Agree {
 		err = writer.AddChar(1)
@@ -10602,7 +10279,6 @@ func (s *TradeCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PartnerPlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -10642,35 +10318,28 @@ func (s *NpcReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// PlayerDirection : field : Direction
 	if err = writer.AddChar(int(s.PlayerDirection)); err != nil {
 		return
 	}
-
 	// NpcIndex : field : short
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	// Damage : field : three
 	if err = writer.AddThree(s.Damage); err != nil {
 		return
 	}
-
 	// HpPercentage : field : short
 	if err = writer.AddShort(s.HpPercentage); err != nil {
 		return
 	}
-
 	// KillStealProtection : field : NpcKillStealProtectionState
 	if s.KillStealProtection != nil {
 		if err = writer.AddChar(int(*s.KillStealProtection)); err != nil {
 			return
 		}
-
 	}
-
 	return
 }
 
@@ -10725,45 +10394,36 @@ func (s *CastReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// CasterId : field : short
 	if err = writer.AddShort(s.CasterId); err != nil {
 		return
 	}
-
 	// CasterDirection : field : Direction
 	if err = writer.AddChar(int(s.CasterDirection)); err != nil {
 		return
 	}
-
 	// NpcIndex : field : short
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	// Damage : field : three
 	if err = writer.AddThree(s.Damage); err != nil {
 		return
 	}
-
 	// HpPercentage : field : short
 	if err = writer.AddShort(s.HpPercentage); err != nil {
 		return
 	}
-
 	// CasterTp : field : short
 	if err = writer.AddShort(s.CasterTp); err != nil {
 		return
 	}
-
 	// KillStealProtection : field : NpcKillStealProtectionState
 	if s.KillStealProtection != nil {
 		if err = writer.AddChar(int(*s.KillStealProtection)); err != nil {
 			return
 		}
-
 	}
-
 	return
 }
 
@@ -10821,9 +10481,7 @@ func (s *NpcSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddInt(*s.Experience); err != nil {
 			return
 		}
-
 	}
-
 	return
 }
 
@@ -10871,7 +10529,6 @@ func (s *NpcAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.Experience); err != nil {
 		return
 	}
-
 	// LevelUp : field : LevelUpStats
 	if err = s.LevelUp.Serialize(writer); err != nil {
 		return
@@ -10921,7 +10578,6 @@ func (s *CastSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// NpcKilledData : field : NpcKilledData
 	if err = s.NpcKilledData.Serialize(writer); err != nil {
 		return
@@ -10930,15 +10586,12 @@ func (s *CastSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.CasterTp); err != nil {
 		return
 	}
-
 	// Experience : field : int
 	if s.Experience != nil {
 		if err = writer.AddInt(*s.Experience); err != nil {
 			return
 		}
-
 	}
-
 	return
 }
 
@@ -10988,7 +10641,6 @@ func (s *CastAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.SpellId); err != nil {
 		return
 	}
-
 	// NpcKilledData : field : NpcKilledData
 	if err = s.NpcKilledData.Serialize(writer); err != nil {
 		return
@@ -10997,12 +10649,10 @@ func (s *CastAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.CasterTp); err != nil {
 		return
 	}
-
 	// Experience : field : int
 	if err = writer.AddInt(s.Experience); err != nil {
 		return
 	}
-
 	// LevelUp : field : LevelUpStats
 	if err = s.LevelUp.Serialize(writer); err != nil {
 		return
@@ -11053,7 +10703,6 @@ func (s *NpcJunkServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.NpcId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -11118,17 +10767,13 @@ func (s *NpcPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddShort(*s.Hp); err != nil {
 			return
 		}
-
 	}
-
 	// Tp : field : short
 	if s.Tp != nil {
 		if err = writer.AddShort(*s.Tp); err != nil {
 			return
 		}
-
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -11208,12 +10853,10 @@ func (s *NpcDialogServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -11254,14 +10897,12 @@ func (s *QuestReportServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.NpcId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Messages : array : string
 	for ndx := 0; ndx < len(s.Messages); ndx++ {
 		if err = writer.AddString(s.Messages[ndx]); err != nil {
 			return
 		}
-
 		writer.AddByte(0xFF)
 	}
 
@@ -11323,27 +10964,22 @@ func (s *QuestDialogServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.QuestCount); err != nil {
 		return
 	}
-
 	// BehaviorId : field : short
 	if err = writer.AddShort(s.BehaviorId); err != nil {
 		return
 	}
-
 	// QuestId : field : short
 	if err = writer.AddShort(s.QuestId); err != nil {
 		return
 	}
-
 	// SessionId : field : short
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// DialogId : field : short
 	if err = writer.AddShort(s.DialogId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// QuestEntries : array : DialogQuestEntry
 	for ndx := 0; ndx < s.QuestCount; ndx++ {
@@ -11468,7 +11104,6 @@ func (s *QuestListPageDataHistory) Serialize(writer *data.EoWriter) (err error) 
 		if err = writer.AddString(s.CompletedQuests[ndx]); err != nil {
 			return
 		}
-
 		writer.AddByte(0xFF)
 	}
 
@@ -11507,12 +11142,10 @@ func (s *QuestListServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Page)); err != nil {
 		return
 	}
-
 	// QuestsCount : field : short
 	if err = writer.AddShort(s.QuestsCount); err != nil {
 		return
 	}
-
 	switch s.Page {
 	case net.QuestPage_Progress:
 		switch s.PageData.(type) {
@@ -11586,7 +11219,6 @@ func (s *ItemAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -11620,7 +11252,6 @@ func (s *ArenaDropServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString("N"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -11657,7 +11288,6 @@ func (s *ArenaUseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.PlayersCount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -11697,31 +11327,26 @@ func (s *ArenaSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Direction : field : Direction
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// KillsCount : field : int
 	if err = writer.AddInt(s.KillsCount); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// KillerName : field : string
 	if err = writer.AddString(s.KillerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// VictimName : field : string
 	if err = writer.AddString(s.VictimName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -11793,25 +11418,21 @@ func (s *ArenaAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.WinnerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// KillsCount : field : int
 	if err = writer.AddInt(s.KillsCount); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// KillerName : field : string
 	if err = writer.AddString(s.KillerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// VictimName : field : string
 	if err = writer.AddString(s.VictimName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	writer.SanitizeStrings = false
 	return
@@ -11877,7 +11498,6 @@ func (s *MarriageOpenServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddThree(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -11913,7 +11533,6 @@ func (s *MarriageReplyReplyCodeDataSuccess) Serialize(writer *data.EoWriter) (er
 	if err = writer.AddInt(s.GoldAmount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -11943,7 +11562,6 @@ func (s *MarriageReplyServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	switch s.ReplyCode {
 	case MarriageReply_Success:
 		switch s.ReplyCodeData.(type) {
@@ -11997,7 +11615,6 @@ func (s *PriestOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.SessionId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12032,7 +11649,6 @@ func (s *PriestReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(int(s.ReplyCode)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12068,12 +11684,10 @@ func (s *PriestRequestServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.SessionId); err != nil {
 		return
 	}
-
 	// PartnerName : field : string
 	if err = writer.AddString(s.PartnerName); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12113,12 +11727,10 @@ func (s *RecoverPlayerServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.Hp); err != nil {
 		return
 	}
-
 	// Tp : field : short
 	if err = writer.AddShort(s.Tp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12157,17 +11769,14 @@ func (s *RecoverAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// HealHp : field : int
 	if err = writer.AddInt(s.HealHp); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12207,7 +11816,6 @@ func (s *RecoverListServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.ClassId); err != nil {
 		return
 	}
-
 	// Stats : field : CharacterStatsUpdate
 	if err = s.Stats.Serialize(writer); err != nil {
 		return
@@ -12254,36 +11862,28 @@ func (s *RecoverReplyServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddInt(s.Experience); err != nil {
 		return
 	}
-
 	// Karma : field : short
 	if err = writer.AddShort(s.Karma); err != nil {
 		return
 	}
-
 	// LevelUp : field : char
 	if s.LevelUp != nil {
 		if err = writer.AddChar(*s.LevelUp); err != nil {
 			return
 		}
-
 	}
-
 	// StatPoints : field : short
 	if s.StatPoints != nil {
 		if err = writer.AddShort(*s.StatPoints); err != nil {
 			return
 		}
-
 	}
-
 	// SkillPoints : field : short
 	if s.SkillPoints != nil {
 		if err = writer.AddShort(*s.SkillPoints); err != nil {
 			return
 		}
-
 	}
-
 	return
 }
 
@@ -12339,27 +11939,22 @@ func (s *RecoverTargetGroupServerPacket) Serialize(writer *data.EoWriter) (err e
 	if err = writer.AddShort(s.StatPoints); err != nil {
 		return
 	}
-
 	// SkillPoints : field : short
 	if err = writer.AddShort(s.SkillPoints); err != nil {
 		return
 	}
-
 	// MaxHp : field : short
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	// MaxTp : field : short
 	if err = writer.AddShort(s.MaxTp); err != nil {
 		return
 	}
-
 	// MaxSp : field : short
 	if err = writer.AddShort(s.MaxSp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12403,7 +11998,6 @@ func (s *EffectUseEffectDataQuake) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddChar(s.QuakeStrength); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12433,7 +12027,6 @@ func (s *EffectUseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Effect)); err != nil {
 		return
 	}
-
 	switch s.Effect {
 	case MapEffect_Quake:
 		switch s.EffectData.(type) {
@@ -12492,7 +12085,6 @@ func (s *EffectAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.EffectId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12534,17 +12126,14 @@ func (s *EffectTargetOtherServerPacket) Serialize(writer *data.EoWriter) (err er
 	if err = writer.AddShort(s.Damage); err != nil {
 		return
 	}
-
 	// Hp : field : short
 	if err = writer.AddShort(s.Hp); err != nil {
 		return
 	}
-
 	// MaxHp : field : short
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	// Others : array : MapDrainDamageOther
 	for ndx := 0; ndx < len(s.Others); ndx++ {
 		if err = s.Others[ndx].Serialize(writer); err != nil {
@@ -12596,7 +12185,6 @@ func (s *EffectReportServerPacket) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddString("S"); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12636,17 +12224,14 @@ func (s *EffectSpecMapDamageTypeDataTpDrain) Serialize(writer *data.EoWriter) (e
 	if err = writer.AddShort(s.TpDamage); err != nil {
 		return
 	}
-
 	// Tp : field : short
 	if err = writer.AddShort(s.Tp); err != nil {
 		return
 	}
-
 	// MaxTp : field : short
 	if err = writer.AddShort(s.MaxTp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12678,17 +12263,14 @@ func (s *EffectSpecMapDamageTypeDataSpikes) Serialize(writer *data.EoWriter) (er
 	if err = writer.AddShort(s.HpDamage); err != nil {
 		return
 	}
-
 	// Hp : field : short
 	if err = writer.AddShort(s.Hp); err != nil {
 		return
 	}
-
 	// MaxHp : field : short
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12722,7 +12304,6 @@ func (s *EffectSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.MapDamageType)); err != nil {
 		return
 	}
-
 	switch s.MapDamageType {
 	case MapDamage_TpDrain:
 		switch s.MapDamageTypeData.(type) {
@@ -12794,12 +12375,10 @@ func (s *EffectAdminServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	// Died : field : bool
 	if s.Died {
 		err = writer.AddChar(1)
@@ -12814,7 +12393,6 @@ func (s *EffectAdminServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddThree(s.Damage); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -12859,7 +12437,6 @@ func (s *MusicPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.SoundId); err != nil {
 		return
 	}
-
 	return
 }
 

--- a/pkg/eolib/protocol/net/server/packets_generated.go
+++ b/pkg/eolib/protocol/net/server/packets_generated.go
@@ -2330,6 +2330,7 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Deserialize(reader *data.Eo
 	s.MapId = reader.GetShort()
 	// MapRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.MapRid = append(s.MapRid, 0)
 		s.MapRid[ndx] = reader.GetShort()
 	}
 
@@ -2337,6 +2338,7 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Deserialize(reader *data.Eo
 	s.MapFileSize = reader.GetThree()
 	// EifRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.EifRid = append(s.EifRid, 0)
 		s.EifRid[ndx] = reader.GetShort()
 	}
 
@@ -2344,6 +2346,7 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Deserialize(reader *data.Eo
 	s.EifLength = reader.GetShort()
 	// EnfRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.EnfRid = append(s.EnfRid, 0)
 		s.EnfRid[ndx] = reader.GetShort()
 	}
 
@@ -2351,6 +2354,7 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Deserialize(reader *data.Eo
 	s.EnfLength = reader.GetShort()
 	// EsfRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.EsfRid = append(s.EsfRid, 0)
 		s.EsfRid[ndx] = reader.GetShort()
 	}
 
@@ -2358,6 +2362,7 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Deserialize(reader *data.Eo
 	s.EsfLength = reader.GetShort()
 	// EcfRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.EcfRid = append(s.EcfRid, 0)
 		s.EcfRid[ndx] = reader.GetShort()
 	}
 
@@ -2490,6 +2495,7 @@ func (s *WelcomeReplyWelcomeCodeDataEnterGame) Deserialize(reader *data.EoReader
 	}
 	// News : array : string
 	for ndx := 0; ndx < 9; ndx++ {
+		s.News = append(s.News, "")
 		if s.News[ndx], err = reader.GetString(); err != nil {
 			return
 		}
@@ -3662,6 +3668,7 @@ func (s *MessageAcceptServerPacket) Deserialize(reader *data.EoReader) (err erro
 	reader.SetIsChunked(true)
 	// Messages : array : string
 	for ndx := 0; ndx < 4; ndx++ {
+		s.Messages = append(s.Messages, "")
 		if s.Messages[ndx], err = reader.GetString(); err != nil {
 			return
 		}
@@ -4677,6 +4684,7 @@ func (s *WalkReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	reader.SetIsChunked(true)
 	// PlayerIds : array : short
 	for ndx := 0; ndx < reader.Remaining()/2; ndx++ {
+		s.PlayerIds = append(s.PlayerIds, 0)
 		s.PlayerIds[ndx] = reader.GetShort()
 	}
 
@@ -4685,6 +4693,7 @@ func (s *WalkReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// NpcIndexes : array : char
 	for ndx := 0; ndx < reader.Remaining()/1; ndx++ {
+		s.NpcIndexes = append(s.NpcIndexes, 0)
 		s.NpcIndexes[ndx] = reader.GetChar()
 	}
 
@@ -5319,6 +5328,7 @@ func (s *CitizenOpenServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 	// Questions : array : string
 	for ndx := 0; ndx < 3; ndx++ {
+		s.Questions = append(s.Questions, "")
 		if s.Questions[ndx], err = reader.GetString(); err != nil {
 			return
 		}
@@ -7127,6 +7137,7 @@ func (s *WarpRequestWarpTypeDataMapSwitch) Deserialize(reader *data.EoReader) (e
 
 	// MapRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.MapRid = append(s.MapRid, 0)
 		s.MapRid[ndx] = reader.GetShort()
 	}
 
@@ -7607,6 +7618,7 @@ func (s *BookReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// QuestNames : array : string
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
+		s.QuestNames = append(s.QuestNames, "")
 		if s.QuestNames[ndx], err = reader.GetString(); err != nil {
 			return
 		}
@@ -9021,6 +9033,7 @@ func (s *GuildRankServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	reader.SetIsChunked(true)
 	// Ranks : array : string
 	for ndx := 0; ndx < 9; ndx++ {
+		s.Ranks = append(s.Ranks, "")
 		if s.Ranks[ndx], err = reader.GetString(); err != nil {
 			return
 		}
@@ -9321,6 +9334,7 @@ func (s *GuildReportServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 	// Ranks : array : string
 	for ndx := 0; ndx < 9; ndx++ {
+		s.Ranks = append(s.Ranks, "")
 		if s.Ranks[ndx], err = reader.GetString(); err != nil {
 			return
 		}
@@ -10922,6 +10936,7 @@ func (s *QuestReportServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 	// Messages : array : string
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
+		s.Messages = append(s.Messages, "")
 		if s.Messages[ndx], err = reader.GetString(); err != nil {
 			return
 		}
@@ -11116,6 +11131,7 @@ func (s *QuestListPageDataHistory) Deserialize(reader *data.EoReader) (err error
 
 	// CompletedQuests : array : string
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
+		s.CompletedQuests = append(s.CompletedQuests, "")
 		if s.CompletedQuests[ndx], err = reader.GetString(); err != nil {
 			return
 		}

--- a/pkg/eolib/protocol/net/server/structs_generated.go
+++ b/pkg/eolib/protocol/net/server/structs_generated.go
@@ -335,16 +335,19 @@ func (s *EquipmentWelcome) Deserialize(reader *data.EoReader) (err error) {
 	s.Weapon = reader.GetShort()
 	// Ring : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Ring = append(s.Ring, 0)
 		s.Ring[ndx] = reader.GetShort()
 	}
 
 	// Armlet : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Armlet = append(s.Armlet, 0)
 		s.Armlet[ndx] = reader.GetShort()
 	}
 
 	// Bracer : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Bracer = append(s.Bracer, 0)
 		s.Bracer[ndx] = reader.GetShort()
 	}
 
@@ -455,16 +458,19 @@ func (s *EquipmentPaperdoll) Deserialize(reader *data.EoReader) (err error) {
 	s.Weapon = reader.GetShort()
 	// Ring : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Ring = append(s.Ring, 0)
 		s.Ring[ndx] = reader.GetShort()
 	}
 
 	// Armlet : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Armlet = append(s.Armlet, 0)
 		s.Armlet[ndx] = reader.GetShort()
 	}
 
 	// Bracer : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Bracer = append(s.Bracer, 0)
 		s.Bracer[ndx] = reader.GetShort()
 	}
 
@@ -1192,6 +1198,7 @@ func (s *PlayersListFriends) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// Players : array : string
 	for ndx := 0; ndx < s.PlayersCount; ndx++ {
+		s.Players = append(s.Players, "")
 		if s.Players[ndx], err = reader.GetString(); err != nil {
 			return
 		}
@@ -2292,6 +2299,7 @@ func (s *SkillLearn) Deserialize(reader *data.EoReader) (err error) {
 	s.Cost = reader.GetInt()
 	// SkillRequirements : array : short
 	for ndx := 0; ndx < 4; ndx++ {
+		s.SkillRequirements = append(s.SkillRequirements, 0)
 		s.SkillRequirements[ndx] = reader.GetShort()
 	}
 

--- a/pkg/eolib/protocol/net/server/structs_generated.go
+++ b/pkg/eolib/protocol/net/server/structs_generated.go
@@ -24,12 +24,10 @@ func (s *BigCoords) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.X); err != nil {
 		return
 	}
-
 	// Y : field : short
 	if err = writer.AddShort(s.Y); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -62,27 +60,22 @@ func (s *EquipmentChange) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Boots); err != nil {
 		return
 	}
-
 	// Armor : field : short
 	if err = writer.AddShort(s.Armor); err != nil {
 		return
 	}
-
 	// Hat : field : short
 	if err = writer.AddShort(s.Hat); err != nil {
 		return
 	}
-
 	// Weapon : field : short
 	if err = writer.AddShort(s.Weapon); err != nil {
 		return
 	}
-
 	// Shield : field : short
 	if err = writer.AddShort(s.Shield); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -123,47 +116,38 @@ func (s *EquipmentMapInfo) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Boots); err != nil {
 		return
 	}
-
 	//  : field : short
 	if err = writer.AddShort(0); err != nil {
 		return
 	}
-
 	//  : field : short
 	if err = writer.AddShort(0); err != nil {
 		return
 	}
-
 	//  : field : short
 	if err = writer.AddShort(0); err != nil {
 		return
 	}
-
 	// Armor : field : short
 	if err = writer.AddShort(s.Armor); err != nil {
 		return
 	}
-
 	//  : field : short
 	if err = writer.AddShort(0); err != nil {
 		return
 	}
-
 	// Hat : field : short
 	if err = writer.AddShort(s.Hat); err != nil {
 		return
 	}
-
 	// Shield : field : short
 	if err = writer.AddShort(s.Shield); err != nil {
 		return
 	}
-
 	// Weapon : field : short
 	if err = writer.AddShort(s.Weapon); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -210,27 +194,22 @@ func (s *EquipmentCharacterSelect) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.Boots); err != nil {
 		return
 	}
-
 	// Armor : field : short
 	if err = writer.AddShort(s.Armor); err != nil {
 		return
 	}
-
 	// Hat : field : short
 	if err = writer.AddShort(s.Hat); err != nil {
 		return
 	}
-
 	// Shield : field : short
 	if err = writer.AddShort(s.Shield); err != nil {
 		return
 	}
-
 	// Weapon : field : short
 	if err = writer.AddShort(s.Weapon); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -276,53 +255,43 @@ func (s *EquipmentWelcome) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Boots); err != nil {
 		return
 	}
-
 	// Gloves : field : short
 	if err = writer.AddShort(s.Gloves); err != nil {
 		return
 	}
-
 	// Accessory : field : short
 	if err = writer.AddShort(s.Accessory); err != nil {
 		return
 	}
-
 	// Armor : field : short
 	if err = writer.AddShort(s.Armor); err != nil {
 		return
 	}
-
 	// Belt : field : short
 	if err = writer.AddShort(s.Belt); err != nil {
 		return
 	}
-
 	// Necklace : field : short
 	if err = writer.AddShort(s.Necklace); err != nil {
 		return
 	}
-
 	// Hat : field : short
 	if err = writer.AddShort(s.Hat); err != nil {
 		return
 	}
-
 	// Shield : field : short
 	if err = writer.AddShort(s.Shield); err != nil {
 		return
 	}
-
 	// Weapon : field : short
 	if err = writer.AddShort(s.Weapon); err != nil {
 		return
 	}
-
 	// Ring : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.Ring[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// Armlet : array : short
@@ -330,7 +299,6 @@ func (s *EquipmentWelcome) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddShort(s.Armlet[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// Bracer : array : short
@@ -338,7 +306,6 @@ func (s *EquipmentWelcome) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddShort(s.Bracer[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	return
@@ -408,53 +375,43 @@ func (s *EquipmentPaperdoll) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Boots); err != nil {
 		return
 	}
-
 	// Accessory : field : short
 	if err = writer.AddShort(s.Accessory); err != nil {
 		return
 	}
-
 	// Gloves : field : short
 	if err = writer.AddShort(s.Gloves); err != nil {
 		return
 	}
-
 	// Belt : field : short
 	if err = writer.AddShort(s.Belt); err != nil {
 		return
 	}
-
 	// Armor : field : short
 	if err = writer.AddShort(s.Armor); err != nil {
 		return
 	}
-
 	// Necklace : field : short
 	if err = writer.AddShort(s.Necklace); err != nil {
 		return
 	}
-
 	// Hat : field : short
 	if err = writer.AddShort(s.Hat); err != nil {
 		return
 	}
-
 	// Shield : field : short
 	if err = writer.AddShort(s.Shield); err != nil {
 		return
 	}
-
 	// Weapon : field : short
 	if err = writer.AddShort(s.Weapon); err != nil {
 		return
 	}
-
 	// Ring : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.Ring[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// Armlet : array : short
@@ -462,7 +419,6 @@ func (s *EquipmentPaperdoll) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddShort(s.Armlet[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// Bracer : array : short
@@ -470,7 +426,6 @@ func (s *EquipmentPaperdoll) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddShort(s.Bracer[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	return
@@ -549,18 +504,15 @@ func (s *CharacterMapInfo) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// PlayerId : field : short
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// MapId : field : short
 	if err = writer.AddShort(s.MapId); err != nil {
 		return
 	}
-
 	// Coords : field : BigCoords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -569,62 +521,50 @@ func (s *CharacterMapInfo) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	// ClassId : field : char
 	if err = writer.AddChar(s.ClassId); err != nil {
 		return
 	}
-
 	// GuildTag : field : string
 	if err = writer.AddFixedString(s.GuildTag, 3); err != nil {
 		return
 	}
-
 	// Level : field : char
 	if err = writer.AddChar(s.Level); err != nil {
 		return
 	}
-
 	// Gender : field : Gender
 	if err = writer.AddChar(int(s.Gender)); err != nil {
 		return
 	}
-
 	// HairStyle : field : char
 	if err = writer.AddChar(s.HairStyle); err != nil {
 		return
 	}
-
 	// HairColor : field : char
 	if err = writer.AddChar(s.HairColor); err != nil {
 		return
 	}
-
 	// Skin : field : char
 	if err = writer.AddChar(s.Skin); err != nil {
 		return
 	}
-
 	// MaxHp : field : short
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	// Hp : field : short
 	if err = writer.AddShort(s.Hp); err != nil {
 		return
 	}
-
 	// MaxTp : field : short
 	if err = writer.AddShort(s.MaxTp); err != nil {
 		return
 	}
-
 	// Tp : field : short
 	if err = writer.AddShort(s.Tp); err != nil {
 		return
 	}
-
 	// Equipment : field : EquipmentMapInfo
 	if err = s.Equipment.Serialize(writer); err != nil {
 		return
@@ -633,7 +573,6 @@ func (s *CharacterMapInfo) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.SitState)); err != nil {
 		return
 	}
-
 	// Invisible : field : bool
 	if s.Invisible {
 		err = writer.AddChar(1)
@@ -649,9 +588,7 @@ func (s *CharacterMapInfo) Serialize(writer *data.EoWriter) (err error) {
 		if err = writer.AddChar(int(*s.WarpEffect)); err != nil {
 			return
 		}
-
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -742,12 +679,10 @@ func (s *NpcMapInfo) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Index); err != nil {
 		return
 	}
-
 	// Id : field : short
 	if err = writer.AddShort(s.Id); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -756,7 +691,6 @@ func (s *NpcMapInfo) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -794,12 +728,10 @@ func (s *ItemMapInfo) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Uid); err != nil {
 		return
 	}
-
 	// Id : field : short
 	if err = writer.AddShort(s.Id); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -808,7 +740,6 @@ func (s *ItemMapInfo) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddThree(s.Amount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -882,12 +813,10 @@ func (s *ChangeTypeDataHair) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.HairStyle); err != nil {
 		return
 	}
-
 	// HairColor : field : char
 	if err = writer.AddChar(s.HairColor); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -915,7 +844,6 @@ func (s *ChangeTypeDataHairColor) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.HairColor); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -937,12 +865,10 @@ func (s *AvatarChange) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// ChangeType : field : AvatarChangeType
 	if err = writer.AddChar(int(s.ChangeType)); err != nil {
 		return
 	}
-
 	// Sound : field : bool
 	if s.Sound {
 		err = writer.AddChar(1)
@@ -1039,7 +965,6 @@ func (s *NearbyInfo) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.CharactersCount); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = true
 	writer.AddByte(0xFF)
 	// Characters : array : CharacterMapInfo
@@ -1127,7 +1052,6 @@ func (s *MapFile) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddBytes(s.Content); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1155,12 +1079,10 @@ func (s *PubFile) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.FileId); err != nil {
 		return
 	}
-
 	// Content : field : blob
 	if err = writer.AddBytes(s.Content); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1191,7 +1113,6 @@ func (s *PlayersList) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayersCount); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Players : array : OnlinePlayer
 	for ndx := 0; ndx < s.PlayersCount; ndx++ {
@@ -1246,14 +1167,12 @@ func (s *PlayersListFriends) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayersCount); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Players : array : string
 	for ndx := 0; ndx < s.PlayersCount; ndx++ {
 		if err = writer.AddString(s.Players[ndx]); err != nil {
 			return
 		}
-
 		writer.AddByte(0xFF)
 	}
 
@@ -1306,34 +1225,28 @@ func (s *OnlinePlayer) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Title : field : string
 	if err = writer.AddString(s.Title); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Level : field : char
 	if err = writer.AddChar(s.Level); err != nil {
 		return
 	}
-
 	// Icon : field : CharacterIcon
 	if err = writer.AddChar(int(s.Icon)); err != nil {
 		return
 	}
-
 	// ClassId : field : char
 	if err = writer.AddChar(s.ClassId); err != nil {
 		return
 	}
-
 	// GuildTag : field : string
 	if err = writer.AddString(s.GuildTag); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -1397,43 +1310,35 @@ func (s *CharacterSelectionListEntry) Serialize(writer *data.EoWriter) (err erro
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Id : field : int
 	if err = writer.AddInt(s.Id); err != nil {
 		return
 	}
-
 	// Level : field : char
 	if err = writer.AddChar(s.Level); err != nil {
 		return
 	}
-
 	// Gender : field : Gender
 	if err = writer.AddChar(int(s.Gender)); err != nil {
 		return
 	}
-
 	// HairStyle : field : char
 	if err = writer.AddChar(s.HairStyle); err != nil {
 		return
 	}
-
 	// HairColor : field : char
 	if err = writer.AddChar(s.HairColor); err != nil {
 		return
 	}
-
 	// Skin : field : char
 	if err = writer.AddChar(s.Skin); err != nil {
 		return
 	}
-
 	// Admin : field : AdminLevel
 	if err = writer.AddChar(int(s.Admin)); err != nil {
 		return
 	}
-
 	// Equipment : field : EquipmentCharacterSelect
 	if err = s.Equipment.Serialize(writer); err != nil {
 		return
@@ -1497,12 +1402,10 @@ func (s *ServerSettings) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.JailMap); err != nil {
 		return
 	}
-
 	// RescueMap : field : short
 	if err = writer.AddShort(s.RescueMap); err != nil {
 		return
 	}
-
 	// RescueCoords : field : Coords
 	if err = s.RescueCoords.Serialize(writer); err != nil {
 		return
@@ -1511,22 +1414,18 @@ func (s *ServerSettings) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.SpyAndLightGuideFloodRate); err != nil {
 		return
 	}
-
 	// GuardianFloodRate : field : short
 	if err = writer.AddShort(s.GuardianFloodRate); err != nil {
 		return
 	}
-
 	// GameMasterFloodRate : field : short
 	if err = writer.AddShort(s.GameMasterFloodRate); err != nil {
 		return
 	}
-
 	// HighGameMasterFloodRate : field : short
 	if err = writer.AddShort(s.HighGameMasterFloodRate); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1570,22 +1469,18 @@ func (s *ShopTradeItem) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	// BuyPrice : field : three
 	if err = writer.AddThree(s.BuyPrice); err != nil {
 		return
 	}
-
 	// SellPrice : field : three
 	if err = writer.AddThree(s.SellPrice); err != nil {
 		return
 	}
-
 	// MaxBuyAmount : field : char
 	if err = writer.AddChar(s.MaxBuyAmount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1619,7 +1514,6 @@ func (s *ShopCraftItem) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.ItemId); err != nil {
 		return
 	}
-
 	// Ingredients : array : CharItem
 	for ndx := 0; ndx < 4; ndx++ {
 		if err = s.Ingredients[ndx].Serialize(writer); err != nil {
@@ -1661,12 +1555,10 @@ func (s *ShopSoldItem) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.Amount); err != nil {
 		return
 	}
-
 	// Id : field : short
 	if err = writer.AddShort(s.Id); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1700,32 +1592,26 @@ func (s *CharacterBaseStats) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Str); err != nil {
 		return
 	}
-
 	// Intl : field : short
 	if err = writer.AddShort(s.Intl); err != nil {
 		return
 	}
-
 	// Wis : field : short
 	if err = writer.AddShort(s.Wis); err != nil {
 		return
 	}
-
 	// Agi : field : short
 	if err = writer.AddShort(s.Agi); err != nil {
 		return
 	}
-
 	// Con : field : short
 	if err = writer.AddShort(s.Con); err != nil {
 		return
 	}
-
 	// Cha : field : short
 	if err = writer.AddShort(s.Cha); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1767,32 +1653,26 @@ func (s *CharacterBaseStatsWelcome) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.Str); err != nil {
 		return
 	}
-
 	// Wis : field : short
 	if err = writer.AddShort(s.Wis); err != nil {
 		return
 	}
-
 	// Intl : field : short
 	if err = writer.AddShort(s.Intl); err != nil {
 		return
 	}
-
 	// Agi : field : short
 	if err = writer.AddShort(s.Agi); err != nil {
 		return
 	}
-
 	// Con : field : short
 	if err = writer.AddShort(s.Con); err != nil {
 		return
 	}
-
 	// Cha : field : short
 	if err = writer.AddShort(s.Cha); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1833,27 +1713,22 @@ func (s *CharacterSecondaryStats) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.MinDamage); err != nil {
 		return
 	}
-
 	// MaxDamage : field : short
 	if err = writer.AddShort(s.MaxDamage); err != nil {
 		return
 	}
-
 	// Accuracy : field : short
 	if err = writer.AddShort(s.Accuracy); err != nil {
 		return
 	}
-
 	// Evade : field : short
 	if err = writer.AddShort(s.Evade); err != nil {
 		return
 	}
-
 	// Armor : field : short
 	if err = writer.AddShort(s.Armor); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1892,27 +1767,22 @@ func (s *CharacterSecondaryStatsInfoLookup) Serialize(writer *data.EoWriter) (er
 	if err = writer.AddShort(s.MaxDamage); err != nil {
 		return
 	}
-
 	// MinDamage : field : short
 	if err = writer.AddShort(s.MinDamage); err != nil {
 		return
 	}
-
 	// Accuracy : field : short
 	if err = writer.AddShort(s.Accuracy); err != nil {
 		return
 	}
-
 	// Evade : field : short
 	if err = writer.AddShort(s.Evade); err != nil {
 		return
 	}
-
 	// Armor : field : short
 	if err = writer.AddShort(s.Armor); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1952,32 +1822,26 @@ func (s *CharacterElementalStats) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Light); err != nil {
 		return
 	}
-
 	// Dark : field : short
 	if err = writer.AddShort(s.Dark); err != nil {
 		return
 	}
-
 	// Fire : field : short
 	if err = writer.AddShort(s.Fire); err != nil {
 		return
 	}
-
 	// Water : field : short
 	if err = writer.AddShort(s.Water); err != nil {
 		return
 	}
-
 	// Earth : field : short
 	if err = writer.AddShort(s.Earth); err != nil {
 		return
 	}
-
 	// Wind : field : short
 	if err = writer.AddShort(s.Wind); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2022,37 +1886,30 @@ func (s *CharacterStatsReset) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.StatPoints); err != nil {
 		return
 	}
-
 	// SkillPoints : field : short
 	if err = writer.AddShort(s.SkillPoints); err != nil {
 		return
 	}
-
 	// Hp : field : short
 	if err = writer.AddShort(s.Hp); err != nil {
 		return
 	}
-
 	// MaxHp : field : short
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	// Tp : field : short
 	if err = writer.AddShort(s.Tp); err != nil {
 		return
 	}
-
 	// MaxTp : field : short
 	if err = writer.AddShort(s.MaxTp); err != nil {
 		return
 	}
-
 	// MaxSp : field : short
 	if err = writer.AddShort(s.MaxSp); err != nil {
 		return
 	}
-
 	// Base : field : CharacterBaseStats
 	if err = s.Base.Serialize(writer); err != nil {
 		return
@@ -2116,42 +1973,34 @@ func (s *CharacterStatsWelcome) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Hp); err != nil {
 		return
 	}
-
 	// MaxHp : field : short
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	// Tp : field : short
 	if err = writer.AddShort(s.Tp); err != nil {
 		return
 	}
-
 	// MaxTp : field : short
 	if err = writer.AddShort(s.MaxTp); err != nil {
 		return
 	}
-
 	// MaxSp : field : short
 	if err = writer.AddShort(s.MaxSp); err != nil {
 		return
 	}
-
 	// StatPoints : field : short
 	if err = writer.AddShort(s.StatPoints); err != nil {
 		return
 	}
-
 	// SkillPoints : field : short
 	if err = writer.AddShort(s.SkillPoints); err != nil {
 		return
 	}
-
 	// Karma : field : short
 	if err = writer.AddShort(s.Karma); err != nil {
 		return
 	}
-
 	// Secondary : field : CharacterSecondaryStats
 	if err = s.Secondary.Serialize(writer); err != nil {
 		return
@@ -2217,22 +2066,18 @@ func (s *CharacterStatsUpdate) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	// MaxTp : field : short
 	if err = writer.AddShort(s.MaxTp); err != nil {
 		return
 	}
-
 	// MaxSp : field : short
 	if err = writer.AddShort(s.MaxSp); err != nil {
 		return
 	}
-
 	// MaxWeight : field : short
 	if err = writer.AddShort(s.MaxWeight); err != nil {
 		return
 	}
-
 	// SecondaryStats : field : CharacterSecondaryStats
 	if err = s.SecondaryStats.Serialize(writer); err != nil {
 		return
@@ -2283,22 +2128,18 @@ func (s *CharacterStatsInfoLookup) Serialize(writer *data.EoWriter) (err error) 
 	if err = writer.AddShort(s.Hp); err != nil {
 		return
 	}
-
 	// MaxHp : field : short
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	// Tp : field : short
 	if err = writer.AddShort(s.Tp); err != nil {
 		return
 	}
-
 	// MaxTp : field : short
 	if err = writer.AddShort(s.MaxTp); err != nil {
 		return
 	}
-
 	// BaseStats : field : CharacterBaseStats
 	if err = s.BaseStats.Serialize(writer); err != nil {
 		return
@@ -2358,12 +2199,10 @@ func (s *CharacterStatsEquipmentChange) Serialize(writer *data.EoWriter) (err er
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	// MaxTp : field : short
 	if err = writer.AddShort(s.MaxTp); err != nil {
 		return
 	}
-
 	// BaseStats : field : CharacterBaseStats
 	if err = s.BaseStats.Serialize(writer); err != nil {
 		return
@@ -2413,28 +2252,23 @@ func (s *SkillLearn) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Id); err != nil {
 		return
 	}
-
 	// LevelRequirement : field : char
 	if err = writer.AddChar(s.LevelRequirement); err != nil {
 		return
 	}
-
 	// ClassRequirement : field : char
 	if err = writer.AddChar(s.ClassRequirement); err != nil {
 		return
 	}
-
 	// Cost : field : int
 	if err = writer.AddInt(s.Cost); err != nil {
 		return
 	}
-
 	// SkillRequirements : array : short
 	for ndx := 0; ndx < 4; ndx++ {
 		if err = writer.AddShort(s.SkillRequirements[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// StatRequirements : field : CharacterBaseStats
@@ -2485,19 +2319,16 @@ func (s *BoardPostListing) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PostId); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Author : field : string
 	if err = writer.AddString(s.Author); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Subject : field : string
 	if err = writer.AddString(s.Subject); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -2553,58 +2384,48 @@ func (s *CharacterDetails) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Home : field : string
 	if err = writer.AddString(s.Home); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Partner : field : string
 	if err = writer.AddString(s.Partner); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Title : field : string
 	if err = writer.AddString(s.Title); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Guild : field : string
 	if err = writer.AddString(s.Guild); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// GuildRank : field : string
 	if err = writer.AddString(s.GuildRank); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// PlayerId : field : short
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// ClassId : field : char
 	if err = writer.AddChar(s.ClassId); err != nil {
 		return
 	}
-
 	// Gender : field : Gender
 	if err = writer.AddChar(int(s.Gender)); err != nil {
 		return
 	}
-
 	// Admin : field : AdminLevel
 	if err = writer.AddChar(int(s.Admin)); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -2692,7 +2513,6 @@ func (s *PartyMember) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Leader : field : bool
 	if s.Leader {
 		err = writer.AddChar(1)
@@ -2707,17 +2527,14 @@ func (s *PartyMember) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Level); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	// Name : field : string
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2760,17 +2577,14 @@ func (s *PartyExpShare) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Experience : field : int
 	if err = writer.AddInt(s.Experience); err != nil {
 		return
 	}
-
 	// LevelUp : field : char
 	if err = writer.AddChar(s.LevelUp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2803,13 +2617,11 @@ func (s *GuildStaff) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Rank); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Name : field : string
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -2850,19 +2662,16 @@ func (s *GuildMember) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Rank); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Name : field : string
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// RankName : field : string
 	if err = writer.AddString(s.RankName); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -2910,17 +2719,14 @@ func (s *GroupHealTargetPlayer) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	// Hp : field : short
 	if err = writer.AddShort(s.Hp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -2955,7 +2761,6 @@ func (s *TradeItemData) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PartnerPlayerId); err != nil {
 		return
 	}
-
 	// PartnerItems : array : Item
 	for ndx := 0; ndx < len(s.PartnerItems); ndx++ {
 		if err = s.PartnerItems[ndx].Serialize(writer); err != nil {
@@ -2968,7 +2773,6 @@ func (s *TradeItemData) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.YourPlayerId); err != nil {
 		return
 	}
-
 	// YourItems : array : Item
 	for ndx := 0; ndx < len(s.YourItems); ndx++ {
 		if err = s.YourItems[ndx].Serialize(writer); err != nil {
@@ -3037,27 +2841,22 @@ func (s *NpcKilledData) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.KillerId); err != nil {
 		return
 	}
-
 	// KillerDirection : field : Direction
 	if err = writer.AddChar(int(s.KillerDirection)); err != nil {
 		return
 	}
-
 	// NpcIndex : field : short
 	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
-
 	// DropIndex : field : short
 	if err = writer.AddShort(s.DropIndex); err != nil {
 		return
 	}
-
 	// DropId : field : short
 	if err = writer.AddShort(s.DropId); err != nil {
 		return
 	}
-
 	// DropCoords : field : Coords
 	if err = s.DropCoords.Serialize(writer); err != nil {
 		return
@@ -3066,12 +2865,10 @@ func (s *NpcKilledData) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddInt(s.DropAmount); err != nil {
 		return
 	}
-
 	// Damage : field : three
 	if err = writer.AddThree(s.Damage); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3119,32 +2916,26 @@ func (s *LevelUpStats) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Level); err != nil {
 		return
 	}
-
 	// StatPoints : field : short
 	if err = writer.AddShort(s.StatPoints); err != nil {
 		return
 	}
-
 	// SkillPoints : field : short
 	if err = writer.AddShort(s.SkillPoints); err != nil {
 		return
 	}
-
 	// MaxHp : field : short
 	if err = writer.AddShort(s.MaxHp); err != nil {
 		return
 	}
-
 	// MaxTp : field : short
 	if err = writer.AddShort(s.MaxTp); err != nil {
 		return
 	}
-
 	// MaxSp : field : short
 	if err = writer.AddShort(s.MaxSp); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3183,7 +2974,6 @@ func (s *NpcUpdatePosition) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.NpcIndex); err != nil {
 		return
 	}
-
 	// Coords : field : Coords
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
@@ -3192,7 +2982,6 @@ func (s *NpcUpdatePosition) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3230,32 +3019,26 @@ func (s *NpcUpdateAttack) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.NpcIndex); err != nil {
 		return
 	}
-
 	// Killed : field : PlayerKilledState
 	if err = writer.AddChar(int(s.Killed)); err != nil {
 		return
 	}
-
 	// Direction : field : Direction
 	if err = writer.AddChar(int(s.Direction)); err != nil {
 		return
 	}
-
 	// PlayerId : field : short
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// Damage : field : three
 	if err = writer.AddThree(s.Damage); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3294,17 +3077,14 @@ func (s *NpcUpdateChat) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.NpcIndex); err != nil {
 		return
 	}
-
 	// MessageLength : length : char
 	if err = writer.AddChar(s.MessageLength); err != nil {
 		return
 	}
-
 	// Message : field : string
 	if err = writer.AddFixedString(s.Message, s.MessageLength); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3342,29 +3122,24 @@ func (s *QuestProgressEntry) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Name); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Description : field : string
 	if err = writer.AddString(s.Description); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Icon : field : QuestRequirementIcon
 	if err = writer.AddShort(int(s.Icon)); err != nil {
 		return
 	}
-
 	// Progress : field : short
 	if err = writer.AddShort(s.Progress); err != nil {
 		return
 	}
-
 	// Target : field : short
 	if err = writer.AddShort(s.Target); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }
@@ -3415,12 +3190,10 @@ func (s *DialogQuestEntry) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.QuestId); err != nil {
 		return
 	}
-
 	// QuestName : field : string
 	if err = writer.AddString(s.QuestName); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3461,7 +3234,6 @@ func (s *EntryTypeDataLink) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.LinkId); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3483,7 +3255,6 @@ func (s *DialogEntry) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(int(s.EntryType)); err != nil {
 		return
 	}
-
 	switch s.EntryType {
 	case DialogEntry_Link:
 		switch s.EntryTypeData.(type) {
@@ -3500,7 +3271,6 @@ func (s *DialogEntry) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.Line); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3540,17 +3310,14 @@ func (s *MapDrainDamageOther) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-
 	// HpPercentage : field : char
 	if err = writer.AddChar(s.HpPercentage); err != nil {
 		return
 	}
-
 	// Damage : field : short
 	if err = writer.AddShort(s.Damage); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -3583,13 +3350,11 @@ func (s *GlobalBackfillMessage) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddString(s.PlayerName); err != nil {
 		return
 	}
-
 	writer.AddByte(0xFF)
 	// Message : field : string
 	if err = writer.AddString(s.Message); err != nil {
 		return
 	}
-
 	writer.SanitizeStrings = false
 	return
 }

--- a/pkg/eolib/protocol/net/server/structs_generated.go
+++ b/pkg/eolib/protocol/net/server/structs_generated.go
@@ -537,7 +537,7 @@ type CharacterMapInfo struct {
 	Equipment  EquipmentMapInfo
 	SitState   SitState
 	Invisible  bool
-	WarpEffect WarpEffect
+	WarpEffect *WarpEffect
 }
 
 func (s *CharacterMapInfo) Serialize(writer *data.EoWriter) (err error) {
@@ -645,8 +645,11 @@ func (s *CharacterMapInfo) Serialize(writer *data.EoWriter) (err error) {
 	}
 
 	// WarpEffect : field : WarpEffect
-	if err = writer.AddChar(int(s.WarpEffect)); err != nil {
-		return
+	if s.WarpEffect != nil {
+		if err = writer.AddChar(int(*s.WarpEffect)); err != nil {
+			return
+		}
+
 	}
 
 	writer.SanitizeStrings = false
@@ -714,7 +717,10 @@ func (s *CharacterMapInfo) Deserialize(reader *data.EoReader) (err error) {
 		s.Invisible = false
 	}
 	// WarpEffect : field : WarpEffect
-	s.WarpEffect = WarpEffect(reader.GetChar())
+	if reader.Remaining() > 0 {
+		s.WarpEffect = new(WarpEffect)
+		*s.WarpEffect = WarpEffect(reader.GetChar())
+	}
 	reader.SetIsChunked(false)
 
 	return

--- a/pkg/eolib/protocol/net/structs_generated.go
+++ b/pkg/eolib/protocol/net/structs_generated.go
@@ -23,17 +23,14 @@ func (s *Version) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Major); err != nil {
 		return
 	}
-
 	// Minor : field : char
 	if err = writer.AddChar(s.Minor); err != nil {
 		return
 	}
-
 	// Patch : field : char
 	if err = writer.AddChar(s.Patch); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -65,12 +62,10 @@ func (s *Weight) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.Current); err != nil {
 		return
 	}
-
 	// Max : field : char
 	if err = writer.AddChar(s.Max); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -100,12 +95,10 @@ func (s *Item) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Id); err != nil {
 		return
 	}
-
 	// Amount : field : int
 	if err = writer.AddInt(s.Amount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -135,12 +128,10 @@ func (s *ThreeItem) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Id); err != nil {
 		return
 	}
-
 	// Amount : field : three
 	if err = writer.AddThree(s.Amount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -170,12 +161,10 @@ func (s *CharItem) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Id); err != nil {
 		return
 	}
-
 	// Amount : field : char
 	if err = writer.AddChar(s.Amount); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -205,12 +194,10 @@ func (s *Spell) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(s.Id); err != nil {
 		return
 	}
-
 	// Level : field : short
 	if err = writer.AddShort(s.Level); err != nil {
 		return
 	}
-
 	return
 }
 

--- a/pkg/eolib/protocol/pub/structs_generated.go
+++ b/pkg/eolib/protocol/pub/structs_generated.go
@@ -375,6 +375,7 @@ func (s *Eif) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Rid = append(s.Rid, 0)
 		s.Rid[ndx] = reader.GetShort()
 	}
 
@@ -640,6 +641,7 @@ func (s *Enf) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Rid = append(s.Rid, 0)
 		s.Rid[ndx] = reader.GetShort()
 	}
 
@@ -801,6 +803,7 @@ func (s *Ecf) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Rid = append(s.Rid, 0)
 		s.Rid[ndx] = reader.GetShort()
 	}
 
@@ -1133,6 +1136,7 @@ func (s *Esf) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		s.Rid = append(s.Rid, 0)
 		s.Rid[ndx] = reader.GetShort()
 	}
 

--- a/pkg/eolib/protocol/pub/structs_generated.go
+++ b/pkg/eolib/protocol/pub/structs_generated.go
@@ -62,212 +62,170 @@ func (s *EifRecord) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.NameLength); err != nil {
 		return
 	}
-
 	// Name : field : string
 	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
 		return
 	}
-
 	// GraphicId : field : short
 	if err = writer.AddShort(s.GraphicId); err != nil {
 		return
 	}
-
 	// Type : field : ItemType
 	if err = writer.AddChar(int(s.Type)); err != nil {
 		return
 	}
-
 	// Subtype : field : ItemSubtype
 	if err = writer.AddChar(int(s.Subtype)); err != nil {
 		return
 	}
-
 	// Special : field : ItemSpecial
 	if err = writer.AddChar(int(s.Special)); err != nil {
 		return
 	}
-
 	// Hp : field : short
 	if err = writer.AddShort(s.Hp); err != nil {
 		return
 	}
-
 	// Tp : field : short
 	if err = writer.AddShort(s.Tp); err != nil {
 		return
 	}
-
 	// MinDamage : field : short
 	if err = writer.AddShort(s.MinDamage); err != nil {
 		return
 	}
-
 	// MaxDamage : field : short
 	if err = writer.AddShort(s.MaxDamage); err != nil {
 		return
 	}
-
 	// Accuracy : field : short
 	if err = writer.AddShort(s.Accuracy); err != nil {
 		return
 	}
-
 	// Evade : field : short
 	if err = writer.AddShort(s.Evade); err != nil {
 		return
 	}
-
 	// Armor : field : short
 	if err = writer.AddShort(s.Armor); err != nil {
 		return
 	}
-
 	// ReturnDamage : field : char
 	if err = writer.AddChar(s.ReturnDamage); err != nil {
 		return
 	}
-
 	// Str : field : char
 	if err = writer.AddChar(s.Str); err != nil {
 		return
 	}
-
 	// Intl : field : char
 	if err = writer.AddChar(s.Intl); err != nil {
 		return
 	}
-
 	// Wis : field : char
 	if err = writer.AddChar(s.Wis); err != nil {
 		return
 	}
-
 	// Agi : field : char
 	if err = writer.AddChar(s.Agi); err != nil {
 		return
 	}
-
 	// Con : field : char
 	if err = writer.AddChar(s.Con); err != nil {
 		return
 	}
-
 	// Cha : field : char
 	if err = writer.AddChar(s.Cha); err != nil {
 		return
 	}
-
 	// LightResistance : field : char
 	if err = writer.AddChar(s.LightResistance); err != nil {
 		return
 	}
-
 	// DarkResistance : field : char
 	if err = writer.AddChar(s.DarkResistance); err != nil {
 		return
 	}
-
 	// EarthResistance : field : char
 	if err = writer.AddChar(s.EarthResistance); err != nil {
 		return
 	}
-
 	// AirResistance : field : char
 	if err = writer.AddChar(s.AirResistance); err != nil {
 		return
 	}
-
 	// WaterResistance : field : char
 	if err = writer.AddChar(s.WaterResistance); err != nil {
 		return
 	}
-
 	// FireResistance : field : char
 	if err = writer.AddChar(s.FireResistance); err != nil {
 		return
 	}
-
 	// Spec1 : field : three
 	if err = writer.AddThree(s.Spec1); err != nil {
 		return
 	}
-
 	// Spec2 : field : char
 	if err = writer.AddChar(s.Spec2); err != nil {
 		return
 	}
-
 	// Spec3 : field : char
 	if err = writer.AddChar(s.Spec3); err != nil {
 		return
 	}
-
 	// LevelRequirement : field : short
 	if err = writer.AddShort(s.LevelRequirement); err != nil {
 		return
 	}
-
 	// ClassRequirement : field : short
 	if err = writer.AddShort(s.ClassRequirement); err != nil {
 		return
 	}
-
 	// StrRequirement : field : short
 	if err = writer.AddShort(s.StrRequirement); err != nil {
 		return
 	}
-
 	// IntRequirement : field : short
 	if err = writer.AddShort(s.IntRequirement); err != nil {
 		return
 	}
-
 	// WisRequirement : field : short
 	if err = writer.AddShort(s.WisRequirement); err != nil {
 		return
 	}
-
 	// AgiRequirement : field : short
 	if err = writer.AddShort(s.AgiRequirement); err != nil {
 		return
 	}
-
 	// ConRequirement : field : short
 	if err = writer.AddShort(s.ConRequirement); err != nil {
 		return
 	}
-
 	// ChaRequirement : field : short
 	if err = writer.AddShort(s.ChaRequirement); err != nil {
 		return
 	}
-
 	// Element : field : Element
 	if err = writer.AddChar(int(s.Element)); err != nil {
 		return
 	}
-
 	// ElementDamage : field : char
 	if err = writer.AddChar(s.ElementDamage); err != nil {
 		return
 	}
-
 	// Weight : field : char
 	if err = writer.AddChar(s.Weight); err != nil {
 		return
 	}
-
 	//  : field : char
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	// Size : field : ItemSize
 	if err = writer.AddChar(int(s.Size)); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -382,25 +340,21 @@ func (s *Eif) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddFixedString("EIF", 3); err != nil {
 		return
 	}
-
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.Rid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// TotalItemsCount : field : short
 	if err = writer.AddShort(s.TotalItemsCount); err != nil {
 		return
 	}
-
 	// Version : field : char
 	if err = writer.AddChar(s.Version); err != nil {
 		return
 	}
-
 	// Items : array : EifRecord
 	for ndx := 0; ndx < len(s.Items); ndx++ {
 		if err = s.Items[ndx].Serialize(writer); err != nil {
@@ -473,22 +427,18 @@ func (s *EnfRecord) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.NameLength); err != nil {
 		return
 	}
-
 	// Name : field : string
 	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
 		return
 	}
-
 	// GraphicId : field : short
 	if err = writer.AddShort(s.GraphicId); err != nil {
 		return
 	}
-
 	// Race : field : char
 	if err = writer.AddChar(s.Race); err != nil {
 		return
 	}
-
 	// Boss : field : bool:short
 	if s.Boss {
 		err = writer.AddShort(1)
@@ -513,82 +463,66 @@ func (s *EnfRecord) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddShort(int(s.Type)); err != nil {
 		return
 	}
-
 	// BehaviorId : field : short
 	if err = writer.AddShort(s.BehaviorId); err != nil {
 		return
 	}
-
 	// Hp : field : three
 	if err = writer.AddThree(s.Hp); err != nil {
 		return
 	}
-
 	// Tp : field : short
 	if err = writer.AddShort(s.Tp); err != nil {
 		return
 	}
-
 	// MinDamage : field : short
 	if err = writer.AddShort(s.MinDamage); err != nil {
 		return
 	}
-
 	// MaxDamage : field : short
 	if err = writer.AddShort(s.MaxDamage); err != nil {
 		return
 	}
-
 	// Accuracy : field : short
 	if err = writer.AddShort(s.Accuracy); err != nil {
 		return
 	}
-
 	// Evade : field : short
 	if err = writer.AddShort(s.Evade); err != nil {
 		return
 	}
-
 	// Armor : field : short
 	if err = writer.AddShort(s.Armor); err != nil {
 		return
 	}
-
 	// ReturnDamage : field : char
 	if err = writer.AddChar(s.ReturnDamage); err != nil {
 		return
 	}
-
 	// Element : field : Element:short
 	if err = writer.AddChar(int(s.Element)); err != nil {
 		return
 	}
-
 	// ElementDamage : field : short
 	if err = writer.AddShort(s.ElementDamage); err != nil {
 		return
 	}
-
 	// ElementWeakness : field : Element:short
 	if err = writer.AddChar(int(s.ElementWeakness)); err != nil {
 		return
 	}
-
 	// ElementWeaknessDamage : field : short
 	if err = writer.AddShort(s.ElementWeaknessDamage); err != nil {
 		return
 	}
-
 	// Level : field : char
 	if err = writer.AddChar(s.Level); err != nil {
 		return
 	}
-
 	// Experience : field : three
 	if err = writer.AddThree(s.Experience); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -671,25 +605,21 @@ func (s *Enf) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddFixedString("ENF", 3); err != nil {
 		return
 	}
-
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.Rid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// TotalNpcsCount : field : short
 	if err = writer.AddShort(s.TotalNpcsCount); err != nil {
 		return
 	}
-
 	// Version : field : char
 	if err = writer.AddChar(s.Version); err != nil {
 		return
 	}
-
 	// Npcs : array : EnfRecord
 	for ndx := 0; ndx < len(s.Npcs); ndx++ {
 		if err = s.Npcs[ndx].Serialize(writer); err != nil {
@@ -750,52 +680,42 @@ func (s *EcfRecord) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.NameLength); err != nil {
 		return
 	}
-
 	// Name : field : string
 	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
 		return
 	}
-
 	// ParentType : field : char
 	if err = writer.AddChar(s.ParentType); err != nil {
 		return
 	}
-
 	// StatGroup : field : char
 	if err = writer.AddChar(s.StatGroup); err != nil {
 		return
 	}
-
 	// Str : field : short
 	if err = writer.AddShort(s.Str); err != nil {
 		return
 	}
-
 	// Intl : field : short
 	if err = writer.AddShort(s.Intl); err != nil {
 		return
 	}
-
 	// Wis : field : short
 	if err = writer.AddShort(s.Wis); err != nil {
 		return
 	}
-
 	// Agi : field : short
 	if err = writer.AddShort(s.Agi); err != nil {
 		return
 	}
-
 	// Con : field : short
 	if err = writer.AddShort(s.Con); err != nil {
 		return
 	}
-
 	// Cha : field : short
 	if err = writer.AddShort(s.Cha); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -846,25 +766,21 @@ func (s *Ecf) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddFixedString("ECF", 3); err != nil {
 		return
 	}
-
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.Rid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// TotalClassesCount : field : short
 	if err = writer.AddShort(s.TotalClassesCount); err != nil {
 		return
 	}
-
 	// Version : field : char
 	if err = writer.AddChar(s.Version); err != nil {
 		return
 	}
-
 	// Classes : array : EcfRecord
 	for ndx := 0; ndx < len(s.Classes); ndx++ {
 		if err = s.Classes[ndx].Serialize(writer); err != nil {
@@ -949,172 +865,138 @@ func (s *EsfRecord) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.NameLength); err != nil {
 		return
 	}
-
 	// ChantLength : length : char
 	if err = writer.AddChar(s.ChantLength); err != nil {
 		return
 	}
-
 	// Name : field : string
 	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
 		return
 	}
-
 	// Chant : field : string
 	if err = writer.AddFixedString(s.Chant, s.ChantLength); err != nil {
 		return
 	}
-
 	// IconId : field : short
 	if err = writer.AddShort(s.IconId); err != nil {
 		return
 	}
-
 	// GraphicId : field : short
 	if err = writer.AddShort(s.GraphicId); err != nil {
 		return
 	}
-
 	// TpCost : field : short
 	if err = writer.AddShort(s.TpCost); err != nil {
 		return
 	}
-
 	// SpCost : field : short
 	if err = writer.AddShort(s.SpCost); err != nil {
 		return
 	}
-
 	// CastTime : field : char
 	if err = writer.AddChar(s.CastTime); err != nil {
 		return
 	}
-
 	// Nature : field : SkillNature
 	if err = writer.AddChar(int(s.Nature)); err != nil {
 		return
 	}
-
 	//  : field : char
 	if err = writer.AddChar(1); err != nil {
 		return
 	}
-
 	// Type : field : SkillType
 	if err = writer.AddThree(int(s.Type)); err != nil {
 		return
 	}
-
 	// Element : field : Element
 	if err = writer.AddChar(int(s.Element)); err != nil {
 		return
 	}
-
 	// ElementPower : field : short
 	if err = writer.AddShort(s.ElementPower); err != nil {
 		return
 	}
-
 	// TargetRestrict : field : SkillTargetRestrict
 	if err = writer.AddChar(int(s.TargetRestrict)); err != nil {
 		return
 	}
-
 	// TargetType : field : SkillTargetType
 	if err = writer.AddChar(int(s.TargetType)); err != nil {
 		return
 	}
-
 	// TargetTime : field : char
 	if err = writer.AddChar(s.TargetTime); err != nil {
 		return
 	}
-
 	//  : field : char
 	if err = writer.AddChar(0); err != nil {
 		return
 	}
-
 	// MaxSkillLevel : field : short
 	if err = writer.AddShort(s.MaxSkillLevel); err != nil {
 		return
 	}
-
 	// MinDamage : field : short
 	if err = writer.AddShort(s.MinDamage); err != nil {
 		return
 	}
-
 	// MaxDamage : field : short
 	if err = writer.AddShort(s.MaxDamage); err != nil {
 		return
 	}
-
 	// Accuracy : field : short
 	if err = writer.AddShort(s.Accuracy); err != nil {
 		return
 	}
-
 	// Evade : field : short
 	if err = writer.AddShort(s.Evade); err != nil {
 		return
 	}
-
 	// Armor : field : short
 	if err = writer.AddShort(s.Armor); err != nil {
 		return
 	}
-
 	// ReturnDamage : field : char
 	if err = writer.AddChar(s.ReturnDamage); err != nil {
 		return
 	}
-
 	// HpHeal : field : short
 	if err = writer.AddShort(s.HpHeal); err != nil {
 		return
 	}
-
 	// TpHeal : field : short
 	if err = writer.AddShort(s.TpHeal); err != nil {
 		return
 	}
-
 	// SpHeal : field : char
 	if err = writer.AddChar(s.SpHeal); err != nil {
 		return
 	}
-
 	// Str : field : short
 	if err = writer.AddShort(s.Str); err != nil {
 		return
 	}
-
 	// Intl : field : short
 	if err = writer.AddShort(s.Intl); err != nil {
 		return
 	}
-
 	// Wis : field : short
 	if err = writer.AddShort(s.Wis); err != nil {
 		return
 	}
-
 	// Agi : field : short
 	if err = writer.AddShort(s.Agi); err != nil {
 		return
 	}
-
 	// Con : field : short
 	if err = writer.AddShort(s.Con); err != nil {
 		return
 	}
-
 	// Cha : field : short
 	if err = writer.AddShort(s.Cha); err != nil {
 		return
 	}
-
 	return
 }
 
@@ -1216,25 +1098,21 @@ func (s *Esf) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddFixedString("ESF", 3); err != nil {
 		return
 	}
-
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		if err = writer.AddShort(s.Rid[ndx]); err != nil {
 			return
 		}
-
 	}
 
 	// TotalSkillsCount : field : short
 	if err = writer.AddShort(s.TotalSkillsCount); err != nil {
 		return
 	}
-
 	// Version : field : char
 	if err = writer.AddChar(s.Version); err != nil {
 		return
 	}
-
 	// Skills : array : EsfRecord
 	for ndx := 0; ndx < len(s.Skills); ndx++ {
 		if err = s.Skills[ndx].Serialize(writer); err != nil {

--- a/pkg/eolib/protocol/structs_generated.go
+++ b/pkg/eolib/protocol/structs_generated.go
@@ -22,12 +22,10 @@ func (s *Coords) Serialize(writer *data.EoWriter) (err error) {
 	if err = writer.AddChar(s.X); err != nil {
 		return
 	}
-
 	// Y : field : char
 	if err = writer.AddChar(s.Y); err != nil {
 		return
 	}
-
 	return
 }
 


### PR DESCRIPTION
- Adds support for the `optional` attribute, which was previously ignored
- Removes a bunch of extra whitespace in generated serialize methods
- Fixes bug when deserializing to slices with primitive types