### PR TITLE
Add top-level package docs

### DIFF
--- a/package.go
+++ b/package.go
@@ -1,4 +1,4 @@
-// eolib-go is the top-level directory for the eolib-go go repository.
+// eolibgo is the top-level package for the Go implementation of eolib.
 //
-// More information is available in the eolib package: [pkg/github.com/ethanmoffat/eolib-go/pkg/eolib]
+// More details are available in the eolib subdirectory: [pkg/github.com/ethanmoffat/eolib-go/pkg/eolib]
 package eolibgo

--- a/package.go
+++ b/package.go
@@ -1,0 +1,4 @@
+// eolib-go is the top-level directory for the eolib-go go repository.
+//
+// More information is available in the eolib package: [pkg/github.com/ethanmoffat/eolib-go/pkg/eolib]
+package eolibgo

--- a/pkg/eolib/package.go
+++ b/pkg/eolib/package.go
@@ -1,0 +1,4 @@
+// eolib is the core library for writing Endless Online applications using the Go programming language.
+//
+// More details are available in the package subdirectories.
+package eolib

--- a/pkg/eolib/package.go
+++ b/pkg/eolib/package.go
@@ -1,4 +1,10 @@
 // eolib is the core library for writing Endless Online applications using the Go programming language.
 //
-// More details are available in the package subdirectories.
+// This package contains top-level functions that are shared between subpackages.
+//
+// More details are available in the package subdirectories:
+//   - [pkg/github.com/ethanmoffat/eolib-go/pkg/eolib/data] :: provides utilities to read and write EO data types.
+//   - [pkg/github.com/ethanmoffat/eolib-go/pkg/eolib/encrypt] :: provides utilities to handle EO data encryption.
+//   - [pkg/github.com/ethanmoffat/eolib-go/pkg/eolib/packet] :: provides utilities for EO packets.
+//   - [pkg/github.com/ethanmoffat/eolib-go/pkg/eolib/protocol] :: provides EO protocol data structures.
 package eolib


### PR DESCRIPTION
Add documentation for top-level package 'eolib-go'. Fixes "no documentation" message on the godoc website and adds link to relevant package with documentation/implementation.