### PR TITLE
Use codegen library Jennifer. Replaces homebrew solution for code generation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 	golang.org/x/text v0.11.0
+	github.com/dave/jennifer v1.7.0
 )
 
 require (
-	github.com/dave/jennifer v1.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/dave/jennifer v1.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/dave/jennifer v1.7.0 h1:uRbSBH9UTS64yXbh4FrMHfgfY762RD+C7bUPKODpSJE=
+github.com/dave/jennifer v1.7.0/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/codegen/enum.go
+++ b/internal/codegen/enum.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	"github.com/dave/jennifer/jen"
+	"github.com/ethanmoffat/eolib-go/internal/codegen/types"
 	"github.com/ethanmoffat/eolib-go/internal/xml"
 )
 
@@ -28,14 +29,14 @@ func GenerateEnums(outputDir string, enums []xml.ProtocolEnum) error {
 		for i, v := range e.Values {
 			var s *jen.Statement
 			if i == 0 {
-				s = jen.Id(fmt.Sprintf("%s_%s", sanitizeTypeName(e.Name), v.Name)).Qual("", e.Name).Op("=").Iota()
+				s = jen.Id(fmt.Sprintf("%s_%s", types.SanitizeTypeName(e.Name), v.Name)).Qual("", e.Name).Op("=").Iota()
 
 				if v.Value > 0 {
 					expected = int(v.Value)
 					s.Op("+").Lit(expected)
 				}
 			} else {
-				s = jen.Id(fmt.Sprintf("%s_%s", sanitizeTypeName(e.Name), v.Name))
+				s = jen.Id(fmt.Sprintf("%s_%s", types.SanitizeTypeName(e.Name), v.Name))
 				actual := int(v.Value)
 				if expected != actual {
 					s.Op("=").Lit(actual)
@@ -51,7 +52,7 @@ func GenerateEnums(outputDir string, enums []xml.ProtocolEnum) error {
 
 		caseList := make([]jen.Code, len(e.Values)+1)
 		for ndx, v := range e.Values {
-			caseList[ndx] = jen.Case(jen.Id(fmt.Sprintf("%s_%s", sanitizeTypeName(e.Name), v.Name))).Block(jen.Return(jen.Lit(v.Name), jen.Nil()))
+			caseList[ndx] = jen.Case(jen.Id(fmt.Sprintf("%s_%s", types.SanitizeTypeName(e.Name), v.Name))).Block(jen.Return(jen.Lit(v.Name), jen.Nil()))
 		}
 		caseList[len(e.Values)] = jen.Default().Block().Return(
 			jen.Lit(""), jen.Qual("fmt", "Errorf").Call(jen.Lit(fmt.Sprintf("could not convert value %%d of type %s to string", e.Name)), jen.Id("e")),

--- a/internal/codegen/enum.go
+++ b/internal/codegen/enum.go
@@ -3,8 +3,8 @@ package codegen
 import (
 	"fmt"
 	"path"
-	"strings"
 
+	"github.com/dave/jennifer/jen"
 	"github.com/ethanmoffat/eolib-go/internal/xml"
 )
 
@@ -16,49 +16,58 @@ func GenerateEnums(outputDir string, enums []xml.ProtocolEnum) error {
 		return err
 	}
 
-	output := strings.Builder{}
-	output.WriteString(packageName + "\n\n")
-	output.WriteString("import \"fmt\"\n\n")
+	f := jen.NewFile(packageName)
 
 	for _, e := range enums {
-		writeTypeComment(&output, e.Name, e.Comment)
+		writeTypeCommentJen(f, e.Name, e.Comment)
 
-		output.WriteString(fmt.Sprintf("type %s int\n\n", e.Name))
-		output.WriteString("const (\n")
+		f.Type().Id(e.Name).Int()
 
+		defsList := make([]jen.Code, len(e.Values))
 		expected := 0
 		for i, v := range e.Values {
+			var s *jen.Statement
 			if i == 0 {
-				output.WriteString(fmt.Sprintf("\t%s_%s %s = iota", sanitizeTypeName(e.Name), v.Name, e.Name))
+				s = jen.Id(fmt.Sprintf("%s_%s", sanitizeTypeName(e.Name), v.Name)).Qual("", e.Name).Op("=").Iota()
+
 				if v.Value > 0 {
-					output.WriteString(fmt.Sprintf(" + %d", v.Value))
 					expected = int(v.Value)
+					s.Op("+").Lit(expected)
 				}
 			} else {
-				output.WriteString(fmt.Sprintf("\t%s_%s", sanitizeTypeName(e.Name), v.Name))
-				if expected != int(v.Value) {
-					output.WriteString(fmt.Sprintf(" = %d", v.Value))
+				s = jen.Id(fmt.Sprintf("%s_%s", sanitizeTypeName(e.Name), v.Name))
+				actual := int(v.Value)
+				if expected != actual {
+					s.Op("=").Lit(actual)
 				}
 			}
 
-			writeInlineComment(&output, v.Comment)
-
-			output.WriteString("\n")
+			writeInlineCommentJen(s, v.Comment)
 			expected += 1
-		}
 
-		output.WriteString(")\n\n")
-
-		output.WriteString(fmt.Sprintf("// String converts a %s value into its string representation\n", e.Name))
-		output.WriteString(fmt.Sprintf("func (e %s) String() (string, error) {\n", e.Name))
-		output.WriteString("\tswitch e {\n")
-		for _, v := range e.Values {
-			output.WriteString(fmt.Sprintf("\tcase %s_%s:\n\t\treturn \"%s\", nil\n", sanitizeTypeName(e.Name), v.Name, v.Name))
+			defsList[i] = s
 		}
-		output.WriteString(fmt.Sprintf("\tdefault:\n\t\treturn \"\", fmt.Errorf(\"could not convert value %%d of type %s to string\", e)\n", e.Name))
-		output.WriteString("\t}\n}\n\n")
+		f.Const().Defs(defsList...)
+
+		caseList := make([]jen.Code, len(e.Values)+1)
+		for ndx, v := range e.Values {
+			caseList[ndx] = jen.Case(jen.Id(fmt.Sprintf("%s_%s", sanitizeTypeName(e.Name), v.Name))).Block(jen.Return(jen.Lit(v.Name), jen.Nil()))
+		}
+		caseList[len(e.Values)] = jen.Default().Block().Return(
+			jen.Lit(""), jen.Qual("fmt", "Errorf").Call(jen.Lit(fmt.Sprintf("could not convert value %%d of type %s to string", e.Name)), jen.Id("e")),
+		)
+
+		f.Commentf("String converts a %s value into its string representation", e.Name)
+		f.Func().Params(
+			// enum receiver
+			jen.Id("e").Id(e.Name),
+		).Id("String").Params(
+		// empty parameter list
+		).Params(jen.String(), jen.Error()).Block(
+			jen.Switch(jen.Id("e").Block(caseList...)),
+		)
 	}
 
 	outFileName := path.Join(outputDir, enumFileName)
-	return writeToFile(outFileName, output.String())
+	return writeToFileJen(f, outFileName)
 }

--- a/internal/codegen/eotype/serializationtype.go
+++ b/internal/codegen/eotype/serializationtype.go
@@ -1,0 +1,93 @@
+package eotype
+
+type SerializationType int
+
+const (
+	Invalid SerializationType = 0
+)
+
+const (
+	Primitive SerializationType = iota + 0x0100 // flag indicating type is a primitive (supported for bool)
+	Byte
+	Char
+	Short
+	Three
+	Int
+	Bool
+)
+
+const (
+	Complex SerializationType = iota + 0x0200 // flag indicating type is complex (not supported for bool)
+	Bytes
+)
+
+const (
+	String SerializationType = iota + 0x0400 // flag indicating type is a string type
+	PaddedString
+	FixedString
+)
+
+const (
+	EncodedString SerializationType = iota + 0x0800 // flag indicating type is an encoded string type
+	PaddedEncodedString
+	FixedEncodedString
+)
+
+// offsets from String or EncodedString to the other string method types
+const (
+	_ SerializationType = iota
+	Padded
+	Fixed
+)
+
+func (t SerializationType) String() string {
+	switch t {
+	case Byte:
+		return "Byte"
+	case Char:
+		return "Char"
+	case Short:
+		return "Short"
+	case Three:
+		return "Three"
+	case Int:
+		return "Int"
+	case Bool:
+		return "Byte"
+	case Bytes:
+		return "Bytes"
+	case String:
+		return "String"
+	case PaddedString:
+		return "PaddedString"
+	case FixedString:
+		return "FixedString"
+	case EncodedString:
+		return "EncodedString"
+	case PaddedEncodedString:
+		return "PaddedEncodedString"
+	case FixedEncodedString:
+		return "FixedEncodedString"
+	}
+
+	return ""
+}
+
+func NewSerializationType(str string) SerializationType {
+	switch str {
+	case "byte":
+		return Byte
+	case "char":
+		return Char
+	case "short":
+		return Short
+	case "three":
+		return Three
+	case "int":
+		return Int
+	case "blob":
+		return Bytes
+	}
+
+	return Invalid
+}

--- a/internal/codegen/packet.go
+++ b/internal/codegen/packet.go
@@ -19,8 +19,9 @@ func GeneratePackets(outputDir string, packets []xml.ProtocolPacket, fullSpec xm
 	}
 
 	f := jen.NewFile(packageName)
-	const netPkg = "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net"
-	f.ImportName(netPkg, "net")
+	for k, v := range packageAliases {
+		f.ImportName(v, k)
+	}
 
 	// collect type names to generate packet structs
 	var typeNames []string
@@ -31,9 +32,9 @@ func GeneratePackets(outputDir string, packets []xml.ProtocolPacket, fullSpec xm
 		for _, p := range packets {
 			typeNames = append(typeNames, p.GetTypeName())
 
-			g.Qual(netPkg, "PacketId").Call(
-				jen.Qual(netPkg, fmt.Sprintf("PacketFamily_%s", p.Family)),
-				jen.Qual(netPkg, fmt.Sprintf("PacketAction_%s", p.Action)),
+			g.Qual(packageAliases["net"], "PacketId").Call(
+				jen.Qual(packageAliases["net"], fmt.Sprintf("PacketFamily_%s", p.Family)),
+				jen.Qual(packageAliases["net"], fmt.Sprintf("PacketAction_%s", p.Action)),
 			).Op(":").Qual("reflect", "TypeOf").Call(
 				jen.Id(snakeCaseToCamelCase(p.GetTypeName())).Values(),
 			).Op(",")
@@ -44,14 +45,14 @@ func GeneratePackets(outputDir string, packets []xml.ProtocolPacket, fullSpec xm
 	f.Comment("This function calls [PacketFromIntegerId] internally.")
 
 	f.Func().Id("PacketFromId").Params(
-		jen.Id("family").Qual(netPkg, "PacketFamily"),
-		jen.Id("action").Qual(netPkg, "PacketAction"),
+		jen.Id("family").Qual(packageAliases["net"], "PacketFamily"),
+		jen.Id("action").Qual(packageAliases["net"], "PacketAction"),
 	).Params(
-		jen.Qual(netPkg, "Packet"),
+		jen.Qual(packageAliases["net"], "Packet"),
 		jen.Error(),
 	).Block(
 		jen.Return(jen.Id("PacketFromIntegerId").Call(
-			jen.Qual(netPkg, "PacketId").Call(jen.Id("family"), jen.Id("action")),
+			jen.Qual(packageAliases["net"], "PacketId").Call(jen.Id("family"), jen.Id("action")),
 		)),
 	)
 
@@ -77,7 +78,7 @@ func GeneratePackets(outputDir string, packets []xml.ProtocolPacket, fullSpec xm
 	f.Func().Id("PacketFromIntegerId").Params(
 		jen.Id("id").Int(), // func declaration: int parameter 'id'
 	).Params(
-		jen.Qual(netPkg, "Packet"), // func declaration: return types (net.Packet, error)
+		jen.Qual(packageAliases["net"], "Packet"), // func declaration: return types (net.Packet, error)
 		jen.Error(),
 	).Block(
 		// try to get the packet type out of the map (indexed by the id)
@@ -90,7 +91,7 @@ func GeneratePackets(outputDir string, packets []xml.ProtocolPacket, fullSpec xm
 		jen.List(jen.Id("packetInstance"), jen.Id("typeOk").Op(":=").Qual("reflect", "New").Call(
 			jen.Id("packetType"),
 		).Dot("Interface").Call().Assert(
-			jen.Qual(netPkg, "Packet"),
+			jen.Qual(packageAliases["net"], "Packet"),
 		)),
 		// check that type is ok, return error otherwise
 		jen.If(jen.Op("!").Id("typeOk")).Block(

--- a/internal/codegen/packet.go
+++ b/internal/codegen/packet.go
@@ -3,41 +3,59 @@ package codegen
 import (
 	"fmt"
 	"path"
-	"strings"
 
+	"github.com/dave/jennifer/jen"
 	"github.com/ethanmoffat/eolib-go/internal/xml"
 )
 
 func GeneratePackets(outputDir string, packets []xml.ProtocolPacket, fullSpec xml.Protocol) error {
-	packageDeclaration, err := getPackageStatement(outputDir)
+	if len(packets) == 0 {
+		return nil
+	}
+
+	packageName, err := getPackageName(outputDir)
 	if err != nil {
 		return err
 	}
 
-	output := strings.Builder{}
-	output.WriteString(packageDeclaration + "\n\n")
-	output.WriteString("import (\n\t\"fmt\"\n\t\"reflect\"\n\t\"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net\"\n)\n\n")
-	output.WriteString("var packetMap = map[int]reflect.Type{\n")
+	f := jen.NewFile(packageName)
+	const netPkg = "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net"
+	f.ImportName(netPkg, "net")
 
 	// collect type names to generate packet structs
 	var typeNames []string
-	for _, p := range packets {
-		typeNames = append(typeNames, p.GetTypeName())
+	f.Var().Id("packetMap").Op("=").Map(jen.Int()).Qual("reflect", "Type").BlockFunc(func(g *jen.Group) {
+		// Note that this block is using "BlockFunc"
+		// Official docs advices to use "Values" with "DictFunc". However, default sorting is alphabetical, which
+		//    creates a nasty git diff of the existing generated code
+		for _, p := range packets {
+			typeNames = append(typeNames, p.GetTypeName())
 
-		output.WriteString(fmt.Sprintf("\tnet.PacketId(net.PacketFamily_%s, net.PacketAction_%s): ", p.Family, p.Action))
-		output.WriteString(fmt.Sprintf("reflect.TypeOf(%s{}),\n", snakeCaseToCamelCase(p.GetTypeName())))
-	}
+			g.Qual(netPkg, "PacketId").Call(
+				jen.Qual(netPkg, fmt.Sprintf("PacketFamily_%s", p.Family)),
+				jen.Qual(netPkg, fmt.Sprintf("PacketAction_%s", p.Action)),
+			).Op(":").Qual("reflect", "TypeOf").Call(
+				jen.Id(snakeCaseToCamelCase(p.GetTypeName())).Values(),
+			).Op(",")
+		}
+	})
 
-	output.WriteString("}\n")
+	f.Comment("PacketFromId creates a typed packet instance from a [net.PacketFamily] and [net.PacketAction].")
+	f.Comment("This function calls [PacketFromIntegerId] internally.")
 
-	output.WriteString(`
-// PacketFromId creates a typed packet instance from a [net.PacketFamily] and [net.PacketAction].
-// This function calls [PacketFromIntegerId] internally.
-func PacketFromId(family net.PacketFamily, action net.PacketAction) (net.Packet, error) {
-	return PacketFromIntegerId(net.PacketId(family, action))
-}
+	f.Func().Id("PacketFromId").Params(
+		jen.Id("family").Qual(netPkg, "PacketFamily"),
+		jen.Id("action").Qual(netPkg, "PacketAction"),
+	).Params(
+		jen.Qual(netPkg, "Packet"),
+		jen.Error(),
+	).Block(
+		jen.Return(jen.Id("PacketFromIntegerId").Call(
+			jen.Qual(netPkg, "PacketId").Call(jen.Id("family"), jen.Id("action")),
+		)),
+	)
 
-// PacketFromIntegerId creates a typed packet instance from a packet's ID. An ID may be converted from a family/action pair via the [net.PacketId] function.
+	f.Comment(`// PacketFromIntegerId creates a typed packet instance from a packet's ID. An ID may be converted from a family/action pair via the [net.PacketId] function.
 // The returned packet implements the [net.Packet] interface. It may be serialized/deserialized without further conversion, or a type assertion may be made to examine the data. The expected type of the assertion is a pointer to a packet structure.
 // The following example does both: an incoming CHAIR_REQUEST packet is deserialized from a reader without converting from the interface type, and the data is examined via a type assertion.
 //
@@ -54,25 +72,37 @@ func PacketFromId(family net.PacketFamily, action net.PacketAction) (net.Packet,
 //      }
 //   default:
 //     fmt.Printf("Unknown type: %s\n", reflect.TypeOf(pkt).Elem().Name())
-//   }
-func PacketFromIntegerId(id int) (net.Packet, error) {
-	packetType, idOk := packetMap[id]
-	if !idOk {
-		return nil, fmt.Errorf("could not find packet with id %d", id)
-	}
+//   }`)
 
-	packetInstance, typeOk := reflect.New(packetType).Interface().(net.Packet)
-	if !typeOk {
-		return nil, fmt.Errorf("could not create packet from id %d", id)
-	}
+	f.Func().Id("PacketFromIntegerId").Params(
+		jen.Id("id").Int(), // func declaration: int parameter 'id'
+	).Params(
+		jen.Qual(netPkg, "Packet"), // func declaration: return types (net.Packet, error)
+		jen.Error(),
+	).Block(
+		// try to get the packet type out of the map (indexed by the id)
+		jen.List(jen.Id("packetType"), jen.Id("idOk")).Op(":=").Id("packetMap").Index(jen.Id("id")),
+		// check that id is ok, return error otherwise
+		jen.If(jen.Op("!").Id("idOk")).Block(
+			jen.Return(jen.List(jen.Nil(), jen.Qual("fmt", "Errorf").Call(jen.Lit("could not find packet with id %d"), jen.Id("id")))),
+		).Line(),
+		// type assert that creating the packet type results in an interface that satisfies net.Packet
+		jen.List(jen.Id("packetInstance"), jen.Id("typeOk").Op(":=").Qual("reflect", "New").Call(
+			jen.Id("packetType"),
+		).Dot("Interface").Call().Assert(
+			jen.Qual(netPkg, "Packet"),
+		)),
+		// check that type is ok, return error otherwise
+		jen.If(jen.Op("!").Id("typeOk")).Block(
+			jen.Return(jen.List(jen.Nil(), jen.Qual("fmt", "Errorf").Call(jen.Lit("could not create packet from id %d"), jen.Id("id")))),
+		).Line(),
+		// return packetInstance, nil
+		jen.Return(jen.Id("packetInstance"), jen.Nil()),
+	)
 
-	return packetInstance, nil
-}
-`)
-
-	if len(packets) > 0 {
-		const packetMapFileName = "packetmap_generated.go"
-		writeToFile(path.Join(outputDir, packetMapFileName), output.String())
+	const packetMapFileName = "packetmap_generated.go"
+	if err := writeToFileJen(f, path.Join(outputDir, packetMapFileName)); err != nil {
+		return err
 	}
 
 	const packetFileName = "packets_generated.go"

--- a/internal/codegen/packet.go
+++ b/internal/codegen/packet.go
@@ -9,13 +9,13 @@ import (
 )
 
 func GeneratePackets(outputDir string, packets []xml.ProtocolPacket, fullSpec xml.Protocol) error {
-	packageName, err := getPackageName(outputDir)
+	packageDeclaration, err := getPackageStatement(outputDir)
 	if err != nil {
 		return err
 	}
 
 	output := strings.Builder{}
-	output.WriteString(packageName + "\n\n")
+	output.WriteString(packageDeclaration + "\n\n")
 	output.WriteString("import (\n\t\"fmt\"\n\t\"reflect\"\n\t\"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net\"\n)\n\n")
 	output.WriteString("var packetMap = map[int]reflect.Type{\n")
 

--- a/internal/codegen/shared.go
+++ b/internal/codegen/shared.go
@@ -70,12 +70,6 @@ func writeTypeCommentJen(f *jen.File, typeName string, comment string) {
 	}
 }
 
-func writeTypeComment(output *strings.Builder, typeName string, comment string) {
-	if comment = sanitizeComment(comment); len(comment) > 0 {
-		output.WriteString(fmt.Sprintf("// %s :: %s\n", typeName, comment))
-	}
-}
-
 func writeInlineCommentJen(c jen.Code, comment string) {
 	if comment = sanitizeComment(comment); len(comment) > 0 {
 		switch v := c.(type) {
@@ -87,32 +81,8 @@ func writeInlineCommentJen(c jen.Code, comment string) {
 	}
 }
 
-func writeInlineComment(output *strings.Builder, comment string) {
-	if comment = sanitizeComment(comment); len(comment) > 0 {
-		output.WriteString(fmt.Sprintf(" // %s", comment))
-	}
-}
-
 func writeToFileJen(f *jen.File, outFileName string) error {
 	return f.Save(outFileName)
-}
-
-func writeToFile(outFileName string, outputText string) error {
-	ofp, err := os.Create(outFileName)
-	if err != nil {
-		return err
-	}
-	defer ofp.Close()
-
-	n, err := ofp.Write([]byte(outputText))
-	if err != nil {
-		return err
-	}
-	if n != len(outputText) {
-		return fmt.Errorf("wrote %d of %d bytes to file %s", n, len(outputText), outFileName)
-	}
-
-	return nil
 }
 
 func snakeCaseToCamelCase(input string) string {

--- a/internal/codegen/shared.go
+++ b/internal/codegen/shared.go
@@ -13,14 +13,6 @@ import (
 	"github.com/ethanmoffat/eolib-go/internal/xml"
 )
 
-// packageAliases is a map of package short names to package paths. For use with Jennifer.
-var packageAliases = map[string]string{
-	"data":     "github.com/ethanmoffat/eolib-go/pkg/eolib/data",
-	"net":      "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net",
-	"protocol": "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol",
-	"pub":      "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/pub",
-}
-
 func getPackageStatement(outputDir string) (string, error) {
 	packageFileName := path.Join(outputDir, "package.go")
 	fp, err := os.Open(packageFileName)

--- a/internal/codegen/shared.go
+++ b/internal/codegen/shared.go
@@ -235,7 +235,7 @@ func calculateTypeSize(typeName string, fullSpec xml.Protocol) (res int, err err
 	var structInfo *xml.ProtocolStruct
 	var isStruct bool
 	if structInfo, isStruct = fullSpec.IsStruct(typeName); !isStruct {
-		return getPrimitizeTypeSize(typeName, fullSpec)
+		return getPrimitiveTypeSize(typeName, fullSpec)
 	}
 
 	var flattenedInstList []xml.ProtocolInstruction
@@ -263,7 +263,7 @@ func calculateTypeSize(typeName string, fullSpec xml.Protocol) (res int, err err
 					return 0, fmt.Errorf("instruction length %s must be a fixed size for %s (%s)", *instruction.Length, *instruction.Name, instruction.XMLName.Local)
 				}
 			} else {
-				if nestedSize, err := getPrimitizeTypeSize(fieldTypeName, fullSpec); err != nil {
+				if nestedSize, err := getPrimitiveTypeSize(fieldTypeName, fullSpec); err != nil {
 					return 0, err
 				} else {
 					res += nestedSize
@@ -279,7 +279,7 @@ func calculateTypeSize(typeName string, fullSpec xml.Protocol) (res int, err err
 	return
 }
 
-func getPrimitizeTypeSize(fieldTypeName string, fullSpec xml.Protocol) (int, error) {
+func getPrimitiveTypeSize(fieldTypeName string, fullSpec xml.Protocol) (int, error) {
 	switch fieldTypeName {
 	case "byte":
 		fallthrough
@@ -304,7 +304,7 @@ func getPrimitizeTypeSize(fieldTypeName string, fullSpec xml.Protocol) (int, err
 			return calculateTypeSize(fieldTypeName, fullSpec)
 		} else if e, isEnum := fullSpec.IsEnum(fieldTypeName); isEnum {
 			enumTypeName := sanitizeTypeName(e.Type)
-			return getPrimitizeTypeSize(enumTypeName, fullSpec)
+			return getPrimitiveTypeSize(enumTypeName, fullSpec)
 		} else {
 			return 0, fmt.Errorf("cannot get fixed size of unrecognized type %s", fieldTypeName)
 		}

--- a/internal/codegen/shared.go
+++ b/internal/codegen/shared.go
@@ -13,6 +13,14 @@ import (
 	"github.com/ethanmoffat/eolib-go/internal/xml"
 )
 
+// packageAliases is a map of package short names to package paths. For use with Jennifer.
+var packageAliases = map[string]string{
+	"data":     "github.com/ethanmoffat/eolib-go/pkg/eolib/data",
+	"net":      "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net",
+	"protocol": "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol",
+	"pub":      "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/pub",
+}
+
 func getPackageStatement(outputDir string) (string, error) {
 	packageFileName := path.Join(outputDir, "package.go")
 	fp, err := os.Open(packageFileName)

--- a/internal/codegen/struct.go
+++ b/internal/codegen/struct.go
@@ -219,10 +219,11 @@ func writeSwitchStructs(f *jen.File, switchInst xml.ProtocolInstruction, si *typ
 		caseStructName := fmt.Sprintf("%s%s", switchInterfaceName, caseName)
 
 		nestedStructInfo := &types.StructInfo{
-			Name:         caseStructName,
-			Comment:      c.Comment,
-			Instructions: c.Instructions,
-			PackageName:  si.PackageName,
+			Name:                  caseStructName,
+			Comment:               c.Comment,
+			Instructions:          c.Instructions,
+			PackageName:           si.PackageName,
+			SwitchStructQualifier: si.SwitchStructQualifier,
 		}
 		err = writeStructShared(f, nestedStructInfo, fullSpec)
 		if err != nil {

--- a/internal/codegen/struct.go
+++ b/internal/codegen/struct.go
@@ -361,7 +361,7 @@ func writeSerializeBody(g *jen.Group, si *types.StructInfo, fullSpec xml.Protoco
 			case "int":
 				fallthrough
 			case "blob":
-				serializeCodes = getSerializeForInstruction(instruction, types.NewSerializationType(typeName), false)
+				serializeCodes = getSerializeForInstruction(instruction, types.NewEoType(typeName), false)
 			case "bool":
 				if len(typeSize) > 0 {
 					typeName = string(unicode.ToUpper(rune(typeSize[0]))) + typeSize[1:]
@@ -402,7 +402,7 @@ func writeSerializeBody(g *jen.Group, si *types.StructInfo, fullSpec xml.Protoco
 						).Block(jen.Return()),
 					}
 				} else if e, ok := fullSpec.IsEnum(typeName); ok {
-					if t := types.NewSerializationType(e.Type); t&types.Primitive > 0 {
+					if t := types.NewEoType(e.Type); t&types.Primitive > 0 {
 						serializeCodes = getSerializeForInstruction(instruction, t, true)
 					}
 				} else {

--- a/internal/codegen/struct.go
+++ b/internal/codegen/struct.go
@@ -110,6 +110,8 @@ func writeStructShared(f *jen.File, si *structInfo, fullSpec xml.Protocol) (err 
 }
 
 func writeStructFields(g *jen.Group, si *structInfo, fullSpec xml.Protocol) (switches []*xml.ProtocolInstruction) {
+	isEmpty := true
+
 	for i, inst := range si.Instructions {
 		var instName string
 
@@ -160,14 +162,20 @@ func writeStructFields(g *jen.Group, si *structInfo, fullSpec xml.Protocol) (swi
 		case "field":
 			if len(instName) > 0 {
 				g.Id(instName).Do(qualifiedTypeName)
+			} else {
+				g.Line()
 			}
+			isEmpty = false
 		case "array":
 			g.Id(instName).Index().Do(qualifiedTypeName)
+			isEmpty = false
 		case "length":
 			g.Id(instName).Do(qualifiedTypeName)
+			isEmpty = false
 		case "switch":
 			g.Id(fmt.Sprintf("%sData", instName)).Id(fmt.Sprintf("%s%sData", si.SwitchStructQualifier, instName))
 			switches = append(switches, &si.Instructions[i])
+			isEmpty = false
 		case "chunked":
 			nestedStructInfo := &structInfo{
 				PackageName:           si.PackageName,
@@ -179,6 +187,10 @@ func writeStructFields(g *jen.Group, si *structInfo, fullSpec xml.Protocol) (swi
 		case "break":
 			continue // no data to write
 		}
+	}
+
+	if isEmpty {
+		g.Line()
 	}
 
 	return

--- a/internal/codegen/struct.go
+++ b/internal/codegen/struct.go
@@ -21,7 +21,7 @@ func GenerateStructs(outputDir string, structs []xml.ProtocolStruct, fullSpec xm
 }
 
 func generateStructsShared(outputDir string, outputFileName string, typeNames []string, fullSpec xml.Protocol) error {
-	packageDeclaration, err := getPackageName(outputDir)
+	packageDeclaration, err := getPackageStatement(outputDir)
 	if err != nil {
 		return err
 	}

--- a/internal/codegen/types/aliases.go
+++ b/internal/codegen/types/aliases.go
@@ -1,0 +1,25 @@
+package types
+
+import "github.com/dave/jennifer/jen"
+
+// packageAliases is a map of package short names to package paths. For use with Jennifer.
+var packageAliases = map[string]string{
+	"data":     "github.com/ethanmoffat/eolib-go/pkg/eolib/data",
+	"net":      "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net",
+	"protocol": "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol",
+	"pub":      "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/pub",
+}
+
+func PackagePath(packageName string) string {
+	if v, ok := packageAliases[packageName]; ok {
+		return v
+	}
+
+	return packageName
+}
+
+func AddImports(f *jen.File) {
+	for k, v := range packageAliases {
+		f.ImportName(v, k)
+	}
+}

--- a/internal/codegen/types/eotype.go
+++ b/internal/codegen/types/eotype.go
@@ -1,13 +1,13 @@
-package eotype
+package types
 
-type SerializationType int
+type EoType int
 
 const (
-	Invalid SerializationType = 0
+	Invalid EoType = 0
 )
 
 const (
-	Primitive SerializationType = iota + 0x0100 // flag indicating type is a primitive (supported for bool)
+	Primitive EoType = iota + 0x0100 // flag indicating type is a primitive (supported for bool)
 	Byte
 	Char
 	Short
@@ -17,30 +17,30 @@ const (
 )
 
 const (
-	Complex SerializationType = iota + 0x0200 // flag indicating type is complex (not supported for bool)
+	Complex EoType = iota + 0x0200 // flag indicating type is complex (not supported for bool)
 	Bytes
 )
 
 const (
-	String SerializationType = iota + 0x0400 // flag indicating type is a string type
+	String EoType = iota + 0x0400 // flag indicating type is a string type
 	PaddedString
 	FixedString
 )
 
 const (
-	EncodedString SerializationType = iota + 0x0800 // flag indicating type is an encoded string type
+	EncodedString EoType = iota + 0x0800 // flag indicating type is an encoded string type
 	PaddedEncodedString
 	FixedEncodedString
 )
 
 // offsets from String or EncodedString to the other string method types
 const (
-	_ SerializationType = iota
+	_ EoType = iota
 	Padded
 	Fixed
 )
 
-func (t SerializationType) String() string {
+func (t EoType) String() string {
 	switch t {
 	case Byte:
 		return "Byte"
@@ -73,7 +73,7 @@ func (t SerializationType) String() string {
 	return ""
 }
 
-func NewSerializationType(str string) SerializationType {
+func NewSerializationType(str string) EoType {
 	switch str {
 	case "byte":
 		return Byte

--- a/internal/codegen/types/eotype.go
+++ b/internal/codegen/types/eotype.go
@@ -73,7 +73,7 @@ func (t EoType) String() string {
 	return ""
 }
 
-func NewSerializationType(str string) EoType {
+func NewEoType(str string) EoType {
 	switch str {
 	case "byte":
 		return Byte

--- a/internal/codegen/types/structinfo.go
+++ b/internal/codegen/types/structinfo.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethanmoffat/eolib-go/internal/xml"
+)
+
+// StructInfo is a type representing the metadata about a struct that should be rendered as generated code.
+// It represents the common properties of either a ProtocolPacket or a ProtocolStruct.
+type StructInfo struct {
+	Name         string                    // Name is the name of the type. It is not converted from protocol naming convention (snake_case).
+	Comment      string                    // Comment is an optional type comment for the struct.
+	Instructions []xml.ProtocolInstruction // Instructions is a collection of instructions for the struct.
+	PackageName  string                    // PackageName is the containing package name for the struct.
+
+	Family                string // Family is the Packet Family of the struct, if the struct is a packet struct.
+	Action                string // Action is the Packet Action of the struct, if the struct is a packet struct.
+	SwitchStructQualifier string // SwitchStructQualifier is an additional qualifier prepended to structs used in switch cases in packets.
+}
+
+// GetStructInfo generates a [StructInfo] for the specified typeName. typeName can be a structure
+// or a packet in the full XML spec.
+func GetStructInfo(typeName string, fullSpec xml.Protocol) (si *StructInfo, err error) {
+	si = &StructInfo{SwitchStructQualifier: ""}
+	err = nil
+
+	if structInfo, ok := fullSpec.IsStruct(typeName); ok {
+		si.Name = structInfo.Name
+		si.Comment = structInfo.Comment
+		si.Instructions = structInfo.Instructions
+		si.PackageName = structInfo.Package
+	} else if packetInfo, ok := fullSpec.IsPacket(typeName); ok {
+		si.Name = packetInfo.GetTypeName()
+		si.Comment = packetInfo.Comment
+		si.Instructions = packetInfo.Instructions
+		si.PackageName = packetInfo.Package
+		si.SwitchStructQualifier = packetInfo.Family + packetInfo.Action
+		si.Family = packetInfo.Family
+		si.Action = packetInfo.Action
+	} else {
+		si = nil
+		err = fmt.Errorf("type %s is not a struct or packet in the spec", typeName)
+	}
+
+	return
+}
+
+// Nested creates a nested [StructInfo] from the specified 'chunked' [xml.ProtocolInstruction].
+// This function returns an error if the instruction is not of the 'chunked' type.
+func (si *StructInfo) Nested(chunked *xml.ProtocolInstruction) (*StructInfo, error) {
+	if chunked.XMLName.Local != "chunked" {
+		return nil, errors.New("expected 'chunked' instruction creating nested StructInfo")
+	}
+
+	return &StructInfo{
+		Instructions:          chunked.Chunked,
+		PackageName:           si.PackageName,
+		SwitchStructQualifier: si.SwitchStructQualifier,
+	}, nil
+}

--- a/internal/codegen/types/typeconv.go
+++ b/internal/codegen/types/typeconv.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"strings"
+
+	"github.com/ethanmoffat/eolib-go/internal/xml"
+)
+
+type ImportInfo struct {
+	Package string
+	Path    string
+}
+
+func ProtocolSpecTypeToGoType(eoType string, currentPackage string, fullSpec xml.Protocol) (goType string, nextImport *ImportInfo) {
+	if strings.ContainsRune(eoType, rune(':')) {
+		eoType = strings.Split(eoType, ":")[0]
+	}
+
+	switch eoType {
+	case "byte":
+		fallthrough
+	case "char":
+		fallthrough
+	case "short":
+		fallthrough
+	case "three":
+		fallthrough
+	case "int":
+		return "int", nil
+	case "bool":
+		return "bool", nil
+	case "blob":
+		return "[]byte", nil
+	case "string":
+		fallthrough
+	case "encoded_string":
+		return "string", nil
+	default:
+		match := fullSpec.FindType(eoType)
+		goType = eoType
+
+		if structMatch, ok := match.(*xml.ProtocolStruct); ok && structMatch.Package != currentPackage {
+			nextImport = &ImportInfo{structMatch.Package, structMatch.PackagePath}
+		} else if enumMatch, ok := match.(*xml.ProtocolEnum); ok && enumMatch.Package != currentPackage {
+			nextImport = &ImportInfo{enumMatch.Package, enumMatch.PackagePath}
+		}
+
+		if nextImport != nil {
+			if val, ok := packageAliases[nextImport.Package]; ok {
+				nextImport.Path = val
+			}
+		}
+
+		return
+	}
+}

--- a/internal/codegen/types/typesize.go
+++ b/internal/codegen/types/typesize.go
@@ -1,0 +1,115 @@
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ethanmoffat/eolib-go/internal/xml"
+)
+
+// SanitizeTypeName sanitizes the type name for serialization. Effectively, this removes the 'Type'
+// suffix if present.
+func SanitizeTypeName(typeName string) string {
+	if strings.HasSuffix(typeName, "Type") {
+		return typeName[:len(typeName)-4]
+	}
+	return typeName
+}
+
+// GetInstructionTypeName gets the type name (and byte size, if present) of an instruction.
+func GetInstructionTypeName(inst xml.ProtocolInstruction) (typeName string, typeSize string) {
+	if inst.Type == nil {
+		return
+	}
+
+	if strings.ContainsRune(*inst.Type, rune(':')) {
+		split := strings.Split(*inst.Type, ":")
+		typeName, typeSize = split[0], split[1]
+	} else {
+		typeName = *inst.Type
+	}
+
+	return
+}
+
+// CalculateTypeSize gets the size of the named type by recursively evaluating and summing the size
+// of the named type's members
+func CalculateTypeSize(typeName string, fullSpec xml.Protocol) (res int, err error) {
+	structInfo, isStruct := fullSpec.IsStruct(typeName)
+	if !isStruct {
+		return getPrimitiveTypeSize(typeName, fullSpec)
+	}
+
+	var flattenedInstList []xml.ProtocolInstruction
+	for _, instruction := range (*structInfo).Instructions {
+		if instruction.XMLName.Local == "chunked" {
+			flattenedInstList = append(flattenedInstList, instruction.Chunked...)
+		} else {
+			flattenedInstList = append(flattenedInstList, instruction)
+		}
+	}
+
+	for _, instruction := range flattenedInstList {
+		switch instruction.XMLName.Local {
+		case "field":
+			fieldTypeName, fieldTypeSize := GetInstructionTypeName(instruction)
+			if fieldTypeSize != "" {
+				fieldTypeName = fieldTypeSize
+			}
+
+			if instruction.Length != nil {
+				if length, err := strconv.ParseInt(*instruction.Length, 10, 32); err == nil {
+					// length is a numeric constant
+					res += int(length)
+				} else {
+					return 0, fmt.Errorf("instruction length %s must be a fixed size for %s (%s)", *instruction.Length, *instruction.Name, instruction.XMLName.Local)
+				}
+			} else {
+				if nestedSize, err := getPrimitiveTypeSize(fieldTypeName, fullSpec); err != nil {
+					return 0, err
+				} else {
+					res += nestedSize
+				}
+			}
+		case "break":
+			res += 1
+		case "array":
+		case "dummy":
+		}
+	}
+
+	return
+}
+
+func getPrimitiveTypeSize(fieldTypeName string, fullSpec xml.Protocol) (int, error) {
+	switch fieldTypeName {
+	case "byte":
+		fallthrough
+	case "char":
+		return 1, nil
+	case "short":
+		return 2, nil
+	case "three":
+		return 3, nil
+	case "int":
+		return 4, nil
+	case "bool":
+		return 1, nil
+	case "blob":
+		fallthrough
+	case "string":
+		fallthrough
+	case "encoded_string":
+		return 0, fmt.Errorf("cannot get size of %s without fixed length", fieldTypeName)
+	default:
+		if _, isStruct := fullSpec.IsStruct(fieldTypeName); isStruct {
+			return CalculateTypeSize(fieldTypeName, fullSpec)
+		} else if e, isEnum := fullSpec.IsEnum(fieldTypeName); isEnum {
+			enumTypeName := SanitizeTypeName(e.Type)
+			return getPrimitiveTypeSize(enumTypeName, fullSpec)
+		} else {
+			return 0, fmt.Errorf("cannot get fixed size of unrecognized type %s", fieldTypeName)
+		}
+	}
+}

--- a/pkg/eolib/data/writer.go
+++ b/pkg/eolib/data/writer.go
@@ -31,7 +31,7 @@ func (w *EoWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// AddInt adds a raw byte to the writer data.
+// AddByte adds a raw byte to the writer data.
 func (w *EoWriter) AddByte(value int) error {
 	if value > 0xFF {
 		return errors.New("value is larger than maximum raw byte size")

--- a/pkg/eolib/protocol/map/structs_generated.go
+++ b/pkg/eolib/protocol/map/structs_generated.go
@@ -1,13 +1,9 @@
 package eomap
 
 import (
-	"fmt"
 	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
-	protocol "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
 )
-
-// Ensure fmt import is referenced in generated code
-var _ = fmt.Printf
 
 // MapNpc :: NPC spawn EMF entity.
 type MapNpc struct {

--- a/pkg/eolib/protocol/net/client/packets_generated.go
+++ b/pkg/eolib/protocol/net/client/packets_generated.go
@@ -3,12 +3,9 @@ package client
 import (
 	"fmt"
 	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
-	protocol "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
-	net "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net"
 )
-
-// Ensure fmt import is referenced in generated code
-var _ = fmt.Printf
 
 // InitInitClientPacket ::  Connection initialization request. This packet is unencrypted.
 type InitInitClientPacket struct {

--- a/pkg/eolib/protocol/net/client/structs_generated.go
+++ b/pkg/eolib/protocol/net/client/structs_generated.go
@@ -1,13 +1,9 @@
 package client
 
 import (
-	"fmt"
 	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
-	protocol "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
 )
-
-// Ensure fmt import is referenced in generated code
-var _ = fmt.Printf
 
 // ByteCoords :: Map coordinates with raw 1-byte values.
 type ByteCoords struct {

--- a/pkg/eolib/protocol/net/server/packets_generated.go
+++ b/pkg/eolib/protocol/net/server/packets_generated.go
@@ -3,13 +3,10 @@ package server
 import (
 	"fmt"
 	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
-	protocol "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
-	net "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net"
-	pub "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/pub"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/pub"
 )
-
-// Ensure fmt import is referenced in generated code
-var _ = fmt.Printf
 
 // InitInitServerPacket ::  Reply to connection initialization and requests for unencrypted data. This packet is unencrypted.
 type InitInitServerPacket struct {
@@ -110,19 +107,19 @@ func (s *InitInitReplyCodeDataOk) Deserialize(reader *data.EoReader) (err error)
 
 type InitInitReplyCodeDataBanned struct {
 	BanType     InitBanType
-	BanTypeData InitInitBanTypeData
+	BanTypeData BanTypeData
 }
 
-type InitInitBanTypeData interface {
+type BanTypeData interface {
 	protocol.EoData
 }
 
-// InitInitBanTypeData0 ::  The official client treats any value below 2 as a temporary ban. The official server sends 1, but some game server implementations. erroneously send 0.
-type InitInitBanTypeData0 struct {
+// BanTypeData0 ::  The official client treats any value below 2 as a temporary ban. The official server sends 1, but some game server implementations. erroneously send 0.
+type BanTypeData0 struct {
 	MinutesRemaining int
 }
 
-func (s *InitInitBanTypeData0) Serialize(writer *data.EoWriter) (err error) {
+func (s *BanTypeData0) Serialize(writer *data.EoWriter) (err error) {
 	oldSanitizeStrings := writer.SanitizeStrings
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
@@ -133,7 +130,7 @@ func (s *InitInitBanTypeData0) Serialize(writer *data.EoWriter) (err error) {
 	return
 }
 
-func (s *InitInitBanTypeData0) Deserialize(reader *data.EoReader) (err error) {
+func (s *BanTypeData0) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
@@ -143,11 +140,11 @@ func (s *InitInitBanTypeData0) Deserialize(reader *data.EoReader) (err error) {
 	return
 }
 
-type InitInitBanTypeDataTemporary struct {
+type BanTypeDataTemporary struct {
 	MinutesRemaining int
 }
 
-func (s *InitInitBanTypeDataTemporary) Serialize(writer *data.EoWriter) (err error) {
+func (s *BanTypeDataTemporary) Serialize(writer *data.EoWriter) (err error) {
 	oldSanitizeStrings := writer.SanitizeStrings
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
@@ -158,7 +155,7 @@ func (s *InitInitBanTypeDataTemporary) Serialize(writer *data.EoWriter) (err err
 	return
 }
 
-func (s *InitInitBanTypeDataTemporary) Deserialize(reader *data.EoReader) (err error) {
+func (s *BanTypeDataTemporary) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
@@ -179,7 +176,7 @@ func (s *InitInitReplyCodeDataBanned) Serialize(writer *data.EoWriter) (err erro
 	switch s.BanType {
 	case 0:
 		switch s.BanTypeData.(type) {
-		case *InitInitBanTypeData0:
+		case *BanTypeData0:
 			if err = s.BanTypeData.Serialize(writer); err != nil {
 				return
 			}
@@ -189,7 +186,7 @@ func (s *InitInitReplyCodeDataBanned) Serialize(writer *data.EoWriter) (err erro
 		}
 	case InitBan_Temporary:
 		switch s.BanTypeData.(type) {
-		case *InitInitBanTypeDataTemporary:
+		case *BanTypeDataTemporary:
 			if err = s.BanTypeData.Serialize(writer); err != nil {
 				return
 			}
@@ -209,12 +206,12 @@ func (s *InitInitReplyCodeDataBanned) Deserialize(reader *data.EoReader) (err er
 	s.BanType = InitBanType(reader.GetByte())
 	switch s.BanType {
 	case 0:
-		s.BanTypeData = &InitInitBanTypeData0{}
+		s.BanTypeData = &BanTypeData0{}
 		if err = s.BanTypeData.Deserialize(reader); err != nil {
 			return
 		}
 	case InitBan_Temporary:
-		s.BanTypeData = &InitInitBanTypeDataTemporary{}
+		s.BanTypeData = &BanTypeDataTemporary{}
 		if err = s.BanTypeData.Deserialize(reader); err != nil {
 			return
 		}
@@ -8104,7 +8101,6 @@ func (s *ChestSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 // ChestCloseServerPacket ::  Reply to trying to interact with a locked or "broken" chest. The official client assumes a broken chest if the packet is under 2 bytes in length.
 type ChestCloseServerPacket struct {
 	Key *int // Sent if the player is trying to interact with a locked chest.
-
 }
 
 func (s ChestCloseServerPacket) Family() net.PacketFamily {

--- a/pkg/eolib/protocol/net/server/packets_generated.go
+++ b/pkg/eolib/protocol/net/server/packets_generated.go
@@ -107,19 +107,19 @@ func (s *InitInitReplyCodeDataOk) Deserialize(reader *data.EoReader) (err error)
 
 type InitInitReplyCodeDataBanned struct {
 	BanType     InitBanType
-	BanTypeData BanTypeData
+	BanTypeData InitInitBanTypeData
 }
 
-type BanTypeData interface {
+type InitInitBanTypeData interface {
 	protocol.EoData
 }
 
-// BanTypeData0 ::  The official client treats any value below 2 as a temporary ban. The official server sends 1, but some game server implementations. erroneously send 0.
-type BanTypeData0 struct {
+// InitInitBanTypeData0 ::  The official client treats any value below 2 as a temporary ban. The official server sends 1, but some game server implementations. erroneously send 0.
+type InitInitBanTypeData0 struct {
 	MinutesRemaining int
 }
 
-func (s *BanTypeData0) Serialize(writer *data.EoWriter) (err error) {
+func (s *InitInitBanTypeData0) Serialize(writer *data.EoWriter) (err error) {
 	oldSanitizeStrings := writer.SanitizeStrings
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
@@ -130,7 +130,7 @@ func (s *BanTypeData0) Serialize(writer *data.EoWriter) (err error) {
 	return
 }
 
-func (s *BanTypeData0) Deserialize(reader *data.EoReader) (err error) {
+func (s *InitInitBanTypeData0) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
@@ -140,11 +140,11 @@ func (s *BanTypeData0) Deserialize(reader *data.EoReader) (err error) {
 	return
 }
 
-type BanTypeDataTemporary struct {
+type InitInitBanTypeDataTemporary struct {
 	MinutesRemaining int
 }
 
-func (s *BanTypeDataTemporary) Serialize(writer *data.EoWriter) (err error) {
+func (s *InitInitBanTypeDataTemporary) Serialize(writer *data.EoWriter) (err error) {
 	oldSanitizeStrings := writer.SanitizeStrings
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
@@ -155,7 +155,7 @@ func (s *BanTypeDataTemporary) Serialize(writer *data.EoWriter) (err error) {
 	return
 }
 
-func (s *BanTypeDataTemporary) Deserialize(reader *data.EoReader) (err error) {
+func (s *InitInitBanTypeDataTemporary) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
@@ -176,7 +176,7 @@ func (s *InitInitReplyCodeDataBanned) Serialize(writer *data.EoWriter) (err erro
 	switch s.BanType {
 	case 0:
 		switch s.BanTypeData.(type) {
-		case *BanTypeData0:
+		case *InitInitBanTypeData0:
 			if err = s.BanTypeData.Serialize(writer); err != nil {
 				return
 			}
@@ -186,7 +186,7 @@ func (s *InitInitReplyCodeDataBanned) Serialize(writer *data.EoWriter) (err erro
 		}
 	case InitBan_Temporary:
 		switch s.BanTypeData.(type) {
-		case *BanTypeDataTemporary:
+		case *InitInitBanTypeDataTemporary:
 			if err = s.BanTypeData.Serialize(writer); err != nil {
 				return
 			}
@@ -206,12 +206,12 @@ func (s *InitInitReplyCodeDataBanned) Deserialize(reader *data.EoReader) (err er
 	s.BanType = InitBanType(reader.GetByte())
 	switch s.BanType {
 	case 0:
-		s.BanTypeData = &BanTypeData0{}
+		s.BanTypeData = &InitInitBanTypeData0{}
 		if err = s.BanTypeData.Deserialize(reader); err != nil {
 			return
 		}
 	case InitBan_Temporary:
-		s.BanTypeData = &BanTypeDataTemporary{}
+		s.BanTypeData = &InitInitBanTypeDataTemporary{}
 		if err = s.BanTypeData.Deserialize(reader); err != nil {
 			return
 		}

--- a/pkg/eolib/protocol/net/server/structs_generated.go
+++ b/pkg/eolib/protocol/net/server/structs_generated.go
@@ -3,12 +3,9 @@ package server
 import (
 	"fmt"
 	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
-	protocol "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
-	net "github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol/net"
 )
-
-// Ensure fmt import is referenced in generated code
-var _ = fmt.Printf
 
 // BigCoords :: Map coordinates with 2-byte values.
 type BigCoords struct {

--- a/pkg/eolib/protocol/net/structs_generated.go
+++ b/pkg/eolib/protocol/net/structs_generated.go
@@ -1,12 +1,6 @@
 package net
 
-import (
-	"fmt"
-	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
-)
-
-// Ensure fmt import is referenced in generated code
-var _ = fmt.Printf
+import "github.com/ethanmoffat/eolib-go/pkg/eolib/data"
 
 // Version :: Client version.
 type Version struct {

--- a/pkg/eolib/protocol/pub/structs_generated.go
+++ b/pkg/eolib/protocol/pub/structs_generated.go
@@ -1,12 +1,6 @@
 package pub
 
-import (
-	"fmt"
-	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
-)
-
-// Ensure fmt import is referenced in generated code
-var _ = fmt.Printf
+import "github.com/ethanmoffat/eolib-go/pkg/eolib/data"
 
 // EifRecord :: Record of Item data in an Endless Item File.
 type EifRecord struct {

--- a/pkg/eolib/protocol/structs_generated.go
+++ b/pkg/eolib/protocol/structs_generated.go
@@ -1,12 +1,6 @@
 package protocol
 
-import (
-	"fmt"
-	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
-)
-
-// Ensure fmt import is referenced in generated code
-var _ = fmt.Printf
+import "github.com/ethanmoffat/eolib-go/pkg/eolib/data"
 
 // Coords :: Map coordinates.
 type Coords struct {


### PR DESCRIPTION
The following major adjustments have been made to code generation:
1. Use a code generation library in place of a homebrew solution.
2. Use `switch` for XML node types instead of `if` and `continue`.
3. Split up helper routines into a subpackage `types`. Contains stuff related to type conversion and type tracking.
4. Remove package-global (unexpected) variables `isChunked` and `outerInstructionList` in favor of method parameters that are passed recursively.

The resulting code is generated slightly differently. A couple of these changes were addressed in a prior commit to reduce the impact on the git diffs for the generated code.
1. `0xFF` is now `255` (limitation of Jennifer library)
2. Comments cannot be prefixed with two space characters (limitation of Jennifer library). Instead of printing an empty instruction name, the instruction content is printed in the comment instead (e.g. for hard-coded/fixed content without a variable)
3. Imports are now managed by Jennifer, and as such, they can be much better optimized. These are reflected in the git diffs.