### PR TITLE
Use Offset from protocol spec when generating code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Core library for writing Endless Online applications using the Go programming la
 The library may be referenced in a project via go get:
 
 ```
-go get github.com/ethanmoffat/eolib-go@v2.0.0
+go get github.com/ethanmoffat/eolib-go@v2.0.1
 ```
 
 ### Sample code

--- a/internal/codegen/struct.go
+++ b/internal/codegen/struct.go
@@ -2,6 +2,7 @@ package codegen
 
 import (
 	"fmt"
+	"math"
 	"path"
 	"strconv"
 	"unicode"
@@ -743,6 +744,16 @@ func getSerializeForInstruction(instruction xml.ProtocolInstruction, methodType 
 		instructionCode = jen.Int().Call(instructionCode)
 	}
 
+	if instruction.Offset != nil {
+		var op string
+		if *instruction.Offset < 0 {
+			op = "+"
+		} else {
+			op = "-"
+		}
+		instructionCode = instructionCode.Op(op).Lit(int(math.Abs(float64(*instruction.Offset))))
+	}
+
 	serializeCode := jen.If(
 		jen.Id("err").Op("=").Id("writer").Dot("Add"+methodType.String()).Call(
 			instructionCode,
@@ -792,6 +803,15 @@ func getDeserializeForInstruction(instruction xml.ProtocolInstruction, methodTyp
 	}
 
 	readerGetCode := jen.Id("reader").Dot("Get" + methodType.String()).Call(lengthExpr)
+	if instruction.Offset != nil {
+		var op string
+		if *instruction.Offset < 0 {
+			op = "-"
+		} else {
+			op = "+"
+		}
+		readerGetCode = readerGetCode.Op(op).Lit(int(math.Abs(float64(*instruction.Offset))))
+	}
 
 	var retCodes []jen.Code
 	var assignRHS, assignLHS *jen.Statement

--- a/pkg/eolib/protocol/map/structs_generated.go
+++ b/pkg/eolib/protocol/map/structs_generated.go
@@ -225,7 +225,7 @@ func (s *MapSign) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// StringDataLength : length : short
-	if err = writer.AddShort(s.StringDataLength); err != nil {
+	if err = writer.AddShort(s.StringDataLength + 1); err != nil {
 		return
 	}
 	// StringData : field : encoded_string
@@ -248,7 +248,7 @@ func (s *MapSign) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// StringDataLength : length : short
-	s.StringDataLength = reader.GetShort()
+	s.StringDataLength = reader.GetShort() - 1
 	// StringData : field : encoded_string
 	if s.StringData, err = reader.GetFixedEncodedString(s.StringDataLength); err != nil {
 		return


### PR DESCRIPTION
Previously unused property. Required for proper (de)serialization of MapSign entities.