### PR TITLE
Fix generated code: bug discovery from eolib-dotnet implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Core library for writing Endless Online applications using the Go programming la
 The library may be referenced in a project via go get:
 
 ```
-go get github.com/ethanmoffat/eolib-go@v2.0.1
+go get github.com/ethanmoffat/eolib-go@v2.0.2
 ```
 
 ### Sample code

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Core library for writing Endless Online applications using the Go programming la
 The library may be referenced in a project via go get:
 
 ```
-go get github.com/ethanmoffat/eolib-go@v2.0.2
+go get github.com/ethanmoffat/eolib-go@v2.1.0
 ```
 
 ### Sample code

--- a/internal/codegen/shared.go
+++ b/internal/codegen/shared.go
@@ -99,7 +99,7 @@ func snakeCaseToCamelCase(input string) string {
 				if ndx != 0 {
 					tmp = tmp + string(unicode.ToUpper(rune(out[ndx+1])))
 				} else {
-					tmp = tmp + string(out[ndx+1])
+					tmp = tmp + string(unicode.ToLower(rune(out[ndx+1])))
 				}
 			}
 

--- a/internal/codegen/types/typesize.go
+++ b/internal/codegen/types/typesize.go
@@ -41,21 +41,13 @@ func CalculateTypeSize(typeName string, fullSpec xml.Protocol) (res int, err err
 		return getPrimitiveTypeSize(typeName, fullSpec)
 	}
 
-	var flattenedInstList []xml.ProtocolInstruction
-	for _, instruction := range (*structInfo).Instructions {
-		if instruction.XMLName.Local == "chunked" {
-			flattenedInstList = append(flattenedInstList, instruction.Chunked...)
-		} else {
-			flattenedInstList = append(flattenedInstList, instruction)
-		}
-	}
-
+	flattenedInstList := xml.Flatten((*structInfo).Instructions)
 	for _, instruction := range flattenedInstList {
 		switch instruction.XMLName.Local {
 		case "array":
 			fallthrough
 		case "field":
-			fieldTypeName, fieldTypeSize := GetInstructionTypeName(instruction)
+			fieldTypeName, fieldTypeSize := GetInstructionTypeName(*instruction)
 			if fieldTypeSize != "" {
 				fieldTypeName = fieldTypeSize
 			}

--- a/internal/xml/models.go
+++ b/internal/xml/models.go
@@ -53,8 +53,12 @@ type ProtocolValue struct {
 }
 
 type ProtocolInstruction struct {
-	XMLName   xml.Name
+	// XMLName is the XML element name of this instruction.
+	XMLName xml.Name
+	// IsChunked is True if this instruction appears within a "chunked" section
 	IsChunked bool
+	// ReferencedBy is the name of the instruction that references this instruction. This is only set for length instructions which are referenced by another instruction.
+	ReferencedBy *string
 
 	// ProtocolField properties
 	Name     *string `xml:"name,attr"`
@@ -98,23 +102,65 @@ type ProtocolCase struct {
 
 type OrdinalValue int
 
-func validate(instructions []ProtocolInstruction, isChunked bool) error {
+func Flatten(instructions []ProtocolInstruction) []*ProtocolInstruction {
+	var flattenedInstList []*ProtocolInstruction
+	for ndx, instruction := range instructions {
+		if instruction.XMLName.Local == "chunked" {
+			flattenedInstList = append(flattenedInstList, Flatten(instruction.Chunked)...)
+		} else {
+			// note: when flattening, switches are *not* flattened as they may have cases with instructions with name collisions
+			// see: CharacterReplyServerPacket
+			flattenedInstList = append(flattenedInstList, &instructions[ndx])
+		}
+	}
+	return flattenedInstList
+}
+
+func getLengthInstructions(instructions []ProtocolInstruction) (lengthInstructions []*ProtocolInstruction) {
+	flattened := Flatten(instructions)
+	for i, inst := range flattened {
+		if inst.XMLName.Local == "length" {
+			lengthInstructions = append(lengthInstructions, flattened[i])
+		}
+	}
+	return
+}
+
+func findLengthInstructionByName(lengthName string, lengthInstructions []*ProtocolInstruction) *ProtocolInstruction {
+	for i, inst := range lengthInstructions {
+		if inst.Name != nil && *inst.Name == lengthName {
+			return lengthInstructions[i]
+		}
+	}
+	return nil
+}
+
+func validate(instructions []ProtocolInstruction, isChunked bool, lengthInstructions []*ProtocolInstruction) error {
+	localLengths := append(lengthInstructions, getLengthInstructions(instructions)...)
+
 	for i, inst := range instructions {
 		if isChunked {
 			instructions[i].IsChunked = true
+		}
+
+		if inst.Length != nil {
+			if lengthInstruction := findLengthInstructionByName(*inst.Length, localLengths); lengthInstruction != nil {
+				lengthInstruction.ReferencedBy = new(string)
+				*lengthInstruction.ReferencedBy = *inst.Name
+			}
 		}
 
 		if err := inst.Validate(); err != nil {
 			return err
 		}
 
-		if err := validate(inst.Chunked, true); err != nil {
+		if err := validate(inst.Chunked, true, localLengths); err != nil {
 			return err
 		}
 
 		if len(inst.Cases) > 0 {
 			for _, cs := range inst.Cases {
-				if err := validate(cs.Instructions, isChunked); err != nil {
+				if err := validate(cs.Instructions, isChunked, localLengths); err != nil {
 					return err
 				}
 			}
@@ -126,13 +172,13 @@ func validate(instructions []ProtocolInstruction, isChunked bool) error {
 
 func (p Protocol) Validate() error {
 	for _, st := range p.Structs {
-		if err := validate(st.Instructions, false); err != nil {
+		if err := validate(st.Instructions, false, nil); err != nil {
 			return err
 		}
 	}
 
 	for _, pkt := range p.Packets {
-		if err := validate(pkt.Instructions, false); err != nil {
+		if err := validate(pkt.Instructions, false, nil); err != nil {
 			return err
 		}
 	}
@@ -206,7 +252,7 @@ func (pi ProtocolInstruction) Validate() error {
 		fieldName := reflectType.Field(i)
 		fieldValue := reflectValue.Field(i)
 
-		if fieldName.Name == "XMLName" || fieldName.Name == "IsChunked" {
+		if fieldName.Name == "XMLName" || fieldName.Name == "IsChunked" || fieldName.Name == "ReferencedBy" {
 			continue
 		}
 

--- a/pkg/eolib/protocol/map/structs_generated.go
+++ b/pkg/eolib/protocol/map/structs_generated.go
@@ -1,6 +1,7 @@
 package eomap
 
 import (
+	"fmt"
 	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
 	"github.com/ethanmoffat/eolib-go/pkg/eolib/protocol"
 )
@@ -707,12 +708,21 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Rid) != 2 {
+			err = fmt.Errorf("expected Rid with length 2, got %d", len(s.Rid))
+			return
+		}
+
 		if err = writer.AddShort(s.Rid[ndx]); err != nil {
 			return
 		}
 	}
 
 	// Name : field : encoded_string
+	if len(s.Name) > 24 {
+		err = fmt.Errorf("expected Name with length 24, got %d", len(s.Name))
+		return
+	}
 	if err = writer.AddPaddedEncodedString(s.Name, 24); err != nil {
 		return
 	}
@@ -837,6 +847,11 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 
 	// GraphicLayers : array : MapGraphicLayer
 	for ndx := 0; ndx < 9; ndx++ {
+		if len(s.GraphicLayers) != 9 {
+			err = fmt.Errorf("expected GraphicLayers with length 9, got %d", len(s.GraphicLayers))
+			return
+		}
+
 		if err = s.GraphicLayers[ndx].Serialize(writer); err != nil {
 			return
 		}

--- a/pkg/eolib/protocol/map/structs_generated.go
+++ b/pkg/eolib/protocol/map/structs_generated.go
@@ -249,10 +249,9 @@ func (s *MapWarp) Deserialize(reader *data.EoReader) (err error) {
 type MapSign struct {
 	byteSize int
 
-	Coords           protocol.Coords
-	StringDataLength int
-	StringData       string
-	TitleLength      int
+	Coords      protocol.Coords
+	StringData  string
+	TitleLength int
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -269,11 +268,11 @@ func (s *MapSign) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// StringDataLength : length : short
-	if err = writer.AddShort(s.StringDataLength + 1); err != nil {
+	if err = writer.AddShort(len(s.StringData) + 1); err != nil {
 		return
 	}
 	// StringData : field : encoded_string
-	if err = writer.AddFixedEncodedString(s.StringData, s.StringDataLength); err != nil {
+	if err = writer.AddFixedEncodedString(s.StringData, len(s.StringData)); err != nil {
 		return
 	}
 	// TitleLength : field : char
@@ -293,9 +292,9 @@ func (s *MapSign) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// StringDataLength : length : short
-	s.StringDataLength = reader.GetShort() - 1
+	stringDataLength := reader.GetShort() - 1
 	// StringData : field : encoded_string
-	if s.StringData, err = reader.GetFixedEncodedString(s.StringDataLength); err != nil {
+	if s.StringData, err = reader.GetFixedEncodedString(stringDataLength); err != nil {
 		return
 	}
 
@@ -352,9 +351,8 @@ func (s *MapTileSpecRowTile) Deserialize(reader *data.EoReader) (err error) {
 type MapTileSpecRow struct {
 	byteSize int
 
-	Y          int
-	TilesCount int
-	Tiles      []MapTileSpecRowTile
+	Y     int
+	Tiles []MapTileSpecRowTile
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -371,11 +369,11 @@ func (s *MapTileSpecRow) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// TilesCount : length : char
-	if err = writer.AddChar(s.TilesCount); err != nil {
+	if err = writer.AddChar(len(s.Tiles)); err != nil {
 		return
 	}
 	// Tiles : array : MapTileSpecRowTile
-	for ndx := 0; ndx < s.TilesCount; ndx++ {
+	for ndx := 0; ndx < len(s.Tiles); ndx++ {
 		if err = s.Tiles[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -392,9 +390,9 @@ func (s *MapTileSpecRow) Deserialize(reader *data.EoReader) (err error) {
 	// Y : field : char
 	s.Y = reader.GetChar()
 	// TilesCount : length : char
-	s.TilesCount = reader.GetChar()
+	tilesCount := reader.GetChar()
 	// Tiles : array : MapTileSpecRowTile
-	for ndx := 0; ndx < s.TilesCount; ndx++ {
+	for ndx := 0; ndx < tilesCount; ndx++ {
 		s.Tiles = append(s.Tiles, MapTileSpecRowTile{})
 		if err = s.Tiles[ndx].Deserialize(reader); err != nil {
 			return
@@ -454,9 +452,8 @@ func (s *MapWarpRowTile) Deserialize(reader *data.EoReader) (err error) {
 type MapWarpRow struct {
 	byteSize int
 
-	Y          int
-	TilesCount int
-	Tiles      []MapWarpRowTile
+	Y     int
+	Tiles []MapWarpRowTile
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -473,11 +470,11 @@ func (s *MapWarpRow) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// TilesCount : length : char
-	if err = writer.AddChar(s.TilesCount); err != nil {
+	if err = writer.AddChar(len(s.Tiles)); err != nil {
 		return
 	}
 	// Tiles : array : MapWarpRowTile
-	for ndx := 0; ndx < s.TilesCount; ndx++ {
+	for ndx := 0; ndx < len(s.Tiles); ndx++ {
 		if err = s.Tiles[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -494,9 +491,9 @@ func (s *MapWarpRow) Deserialize(reader *data.EoReader) (err error) {
 	// Y : field : char
 	s.Y = reader.GetChar()
 	// TilesCount : length : char
-	s.TilesCount = reader.GetChar()
+	tilesCount := reader.GetChar()
 	// Tiles : array : MapWarpRowTile
-	for ndx := 0; ndx < s.TilesCount; ndx++ {
+	for ndx := 0; ndx < tilesCount; ndx++ {
 		s.Tiles = append(s.Tiles, MapWarpRowTile{})
 		if err = s.Tiles[ndx].Deserialize(reader); err != nil {
 			return
@@ -554,9 +551,8 @@ func (s *MapGraphicRowTile) Deserialize(reader *data.EoReader) (err error) {
 type MapGraphicRow struct {
 	byteSize int
 
-	Y          int
-	TilesCount int
-	Tiles      []MapGraphicRowTile
+	Y     int
+	Tiles []MapGraphicRowTile
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -573,11 +569,11 @@ func (s *MapGraphicRow) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// TilesCount : length : char
-	if err = writer.AddChar(s.TilesCount); err != nil {
+	if err = writer.AddChar(len(s.Tiles)); err != nil {
 		return
 	}
 	// Tiles : array : MapGraphicRowTile
-	for ndx := 0; ndx < s.TilesCount; ndx++ {
+	for ndx := 0; ndx < len(s.Tiles); ndx++ {
 		if err = s.Tiles[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -594,9 +590,9 @@ func (s *MapGraphicRow) Deserialize(reader *data.EoReader) (err error) {
 	// Y : field : char
 	s.Y = reader.GetChar()
 	// TilesCount : length : char
-	s.TilesCount = reader.GetChar()
+	tilesCount := reader.GetChar()
 	// Tiles : array : MapGraphicRowTile
-	for ndx := 0; ndx < s.TilesCount; ndx++ {
+	for ndx := 0; ndx < tilesCount; ndx++ {
 		s.Tiles = append(s.Tiles, MapGraphicRowTile{})
 		if err = s.Tiles[ndx].Deserialize(reader); err != nil {
 			return
@@ -612,8 +608,7 @@ func (s *MapGraphicRow) Deserialize(reader *data.EoReader) (err error) {
 type MapGraphicLayer struct {
 	byteSize int
 
-	GraphicRowsCount int
-	GraphicRows      []MapGraphicRow
+	GraphicRows []MapGraphicRow
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -626,11 +621,11 @@ func (s *MapGraphicLayer) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// GraphicRowsCount : length : char
-	if err = writer.AddChar(s.GraphicRowsCount); err != nil {
+	if err = writer.AddChar(len(s.GraphicRows)); err != nil {
 		return
 	}
 	// GraphicRows : array : MapGraphicRow
-	for ndx := 0; ndx < s.GraphicRowsCount; ndx++ {
+	for ndx := 0; ndx < len(s.GraphicRows); ndx++ {
 		if err = s.GraphicRows[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -645,9 +640,9 @@ func (s *MapGraphicLayer) Deserialize(reader *data.EoReader) (err error) {
 
 	readerStartPosition := reader.Position()
 	// GraphicRowsCount : length : char
-	s.GraphicRowsCount = reader.GetChar()
+	graphicRowsCount := reader.GetChar()
 	// GraphicRows : array : MapGraphicRow
-	for ndx := 0; ndx < s.GraphicRowsCount; ndx++ {
+	for ndx := 0; ndx < graphicRowsCount; ndx++ {
 		s.GraphicRows = append(s.GraphicRows, MapGraphicRow{})
 		if err = s.GraphicRows[ndx].Deserialize(reader); err != nil {
 			return
@@ -678,19 +673,13 @@ type Emf struct {
 	RelogX         int
 	RelogY         int
 
-	NpcsCount           int
-	Npcs                []MapNpc
-	LegacyDoorKeysCount int
-	LegacyDoorKeys      []MapLegacyDoorKey
-	ItemsCount          int
-	Items               []MapItem
-	TileSpecRowsCount   int
-	TileSpecRows        []MapTileSpecRow
-	WarpRowsCount       int
-	WarpRows            []MapWarpRow
-	GraphicLayers       []MapGraphicLayer //  The 9 layers of map graphics. Order is [Ground, Object, Overlay, Down Wall, Right Wall, Roof, Top, Shadow, Overlay2].
-	SignsCount          int
-	Signs               []MapSign
+	Npcs           []MapNpc
+	LegacyDoorKeys []MapLegacyDoorKey
+	Items          []MapItem
+	TileSpecRows   []MapTileSpecRow
+	WarpRows       []MapWarpRow
+	GraphicLayers  []MapGraphicLayer //  The 9 layers of map graphics. Order is [Ground, Object, Overlay, Down Wall, Right Wall, Roof, Top, Shadow, Overlay2].
+	Signs          []MapSign
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -791,55 +780,55 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// NpcsCount : length : char
-	if err = writer.AddChar(s.NpcsCount); err != nil {
+	if err = writer.AddChar(len(s.Npcs)); err != nil {
 		return
 	}
 	// Npcs : array : MapNpc
-	for ndx := 0; ndx < s.NpcsCount; ndx++ {
+	for ndx := 0; ndx < len(s.Npcs); ndx++ {
 		if err = s.Npcs[ndx].Serialize(writer); err != nil {
 			return
 		}
 	}
 
 	// LegacyDoorKeysCount : length : char
-	if err = writer.AddChar(s.LegacyDoorKeysCount); err != nil {
+	if err = writer.AddChar(len(s.LegacyDoorKeys)); err != nil {
 		return
 	}
 	// LegacyDoorKeys : array : MapLegacyDoorKey
-	for ndx := 0; ndx < s.LegacyDoorKeysCount; ndx++ {
+	for ndx := 0; ndx < len(s.LegacyDoorKeys); ndx++ {
 		if err = s.LegacyDoorKeys[ndx].Serialize(writer); err != nil {
 			return
 		}
 	}
 
 	// ItemsCount : length : char
-	if err = writer.AddChar(s.ItemsCount); err != nil {
+	if err = writer.AddChar(len(s.Items)); err != nil {
 		return
 	}
 	// Items : array : MapItem
-	for ndx := 0; ndx < s.ItemsCount; ndx++ {
+	for ndx := 0; ndx < len(s.Items); ndx++ {
 		if err = s.Items[ndx].Serialize(writer); err != nil {
 			return
 		}
 	}
 
 	// TileSpecRowsCount : length : char
-	if err = writer.AddChar(s.TileSpecRowsCount); err != nil {
+	if err = writer.AddChar(len(s.TileSpecRows)); err != nil {
 		return
 	}
 	// TileSpecRows : array : MapTileSpecRow
-	for ndx := 0; ndx < s.TileSpecRowsCount; ndx++ {
+	for ndx := 0; ndx < len(s.TileSpecRows); ndx++ {
 		if err = s.TileSpecRows[ndx].Serialize(writer); err != nil {
 			return
 		}
 	}
 
 	// WarpRowsCount : length : char
-	if err = writer.AddChar(s.WarpRowsCount); err != nil {
+	if err = writer.AddChar(len(s.WarpRows)); err != nil {
 		return
 	}
 	// WarpRows : array : MapWarpRow
-	for ndx := 0; ndx < s.WarpRowsCount; ndx++ {
+	for ndx := 0; ndx < len(s.WarpRows); ndx++ {
 		if err = s.WarpRows[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -858,11 +847,11 @@ func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
 	}
 
 	// SignsCount : length : char
-	if err = writer.AddChar(s.SignsCount); err != nil {
+	if err = writer.AddChar(len(s.Signs)); err != nil {
 		return
 	}
 	// Signs : array : MapSign
-	for ndx := 0; ndx < s.SignsCount; ndx++ {
+	for ndx := 0; ndx < len(s.Signs); ndx++ {
 		if err = s.Signs[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -926,9 +915,9 @@ func (s *Emf) Deserialize(reader *data.EoReader) (err error) {
 	// 0 : field : char
 	reader.GetChar()
 	// NpcsCount : length : char
-	s.NpcsCount = reader.GetChar()
+	npcsCount := reader.GetChar()
 	// Npcs : array : MapNpc
-	for ndx := 0; ndx < s.NpcsCount; ndx++ {
+	for ndx := 0; ndx < npcsCount; ndx++ {
 		s.Npcs = append(s.Npcs, MapNpc{})
 		if err = s.Npcs[ndx].Deserialize(reader); err != nil {
 			return
@@ -936,9 +925,9 @@ func (s *Emf) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	// LegacyDoorKeysCount : length : char
-	s.LegacyDoorKeysCount = reader.GetChar()
+	legacyDoorKeysCount := reader.GetChar()
 	// LegacyDoorKeys : array : MapLegacyDoorKey
-	for ndx := 0; ndx < s.LegacyDoorKeysCount; ndx++ {
+	for ndx := 0; ndx < legacyDoorKeysCount; ndx++ {
 		s.LegacyDoorKeys = append(s.LegacyDoorKeys, MapLegacyDoorKey{})
 		if err = s.LegacyDoorKeys[ndx].Deserialize(reader); err != nil {
 			return
@@ -946,9 +935,9 @@ func (s *Emf) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	// ItemsCount : length : char
-	s.ItemsCount = reader.GetChar()
+	itemsCount := reader.GetChar()
 	// Items : array : MapItem
-	for ndx := 0; ndx < s.ItemsCount; ndx++ {
+	for ndx := 0; ndx < itemsCount; ndx++ {
 		s.Items = append(s.Items, MapItem{})
 		if err = s.Items[ndx].Deserialize(reader); err != nil {
 			return
@@ -956,9 +945,9 @@ func (s *Emf) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	// TileSpecRowsCount : length : char
-	s.TileSpecRowsCount = reader.GetChar()
+	tileSpecRowsCount := reader.GetChar()
 	// TileSpecRows : array : MapTileSpecRow
-	for ndx := 0; ndx < s.TileSpecRowsCount; ndx++ {
+	for ndx := 0; ndx < tileSpecRowsCount; ndx++ {
 		s.TileSpecRows = append(s.TileSpecRows, MapTileSpecRow{})
 		if err = s.TileSpecRows[ndx].Deserialize(reader); err != nil {
 			return
@@ -966,9 +955,9 @@ func (s *Emf) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	// WarpRowsCount : length : char
-	s.WarpRowsCount = reader.GetChar()
+	warpRowsCount := reader.GetChar()
 	// WarpRows : array : MapWarpRow
-	for ndx := 0; ndx < s.WarpRowsCount; ndx++ {
+	for ndx := 0; ndx < warpRowsCount; ndx++ {
 		s.WarpRows = append(s.WarpRows, MapWarpRow{})
 		if err = s.WarpRows[ndx].Deserialize(reader); err != nil {
 			return
@@ -984,9 +973,9 @@ func (s *Emf) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	// SignsCount : length : char
-	s.SignsCount = reader.GetChar()
+	signsCount := reader.GetChar()
 	// Signs : array : MapSign
-	for ndx := 0; ndx < s.SignsCount; ndx++ {
+	for ndx := 0; ndx < signsCount; ndx++ {
 		s.Signs = append(s.Signs, MapSign{})
 		if err = s.Signs[ndx].Deserialize(reader); err != nil {
 			return

--- a/pkg/eolib/protocol/map/structs_generated.go
+++ b/pkg/eolib/protocol/map/structs_generated.go
@@ -7,11 +7,18 @@ import (
 
 // MapNpc :: NPC spawn EMF entity.
 type MapNpc struct {
+	byteSize int
+
 	Coords    protocol.Coords
 	Id        int
 	SpawnType int
 	SpawnTime int
 	Amount    int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapNpc) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapNpc) Serialize(writer *data.EoWriter) (err error) {
@@ -45,6 +52,7 @@ func (s *MapNpc) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
@@ -57,14 +65,22 @@ func (s *MapNpc) Deserialize(reader *data.EoReader) (err error) {
 	s.SpawnTime = reader.GetShort()
 	// Amount : field : char
 	s.Amount = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MapLegacyDoorKey :: Legacy EMF entity used to specify a key on a door.
 type MapLegacyDoorKey struct {
+	byteSize int
+
 	Coords protocol.Coords
 	Key    int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapLegacyDoorKey) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapLegacyDoorKey) Serialize(writer *data.EoWriter) (err error) {
@@ -86,24 +102,33 @@ func (s *MapLegacyDoorKey) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
 	// Key : field : short
 	s.Key = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MapItem :: Item spawn EMF entity.
 type MapItem struct {
+	byteSize int
+
 	Coords    protocol.Coords
 	Key       int
 	ChestSlot int
 	ItemId    int
 	SpawnTime int
 	Amount    int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapItem) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapItem) Serialize(writer *data.EoWriter) (err error) {
@@ -141,6 +166,7 @@ func (s *MapItem) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
@@ -155,16 +181,24 @@ func (s *MapItem) Deserialize(reader *data.EoReader) (err error) {
 	s.SpawnTime = reader.GetShort()
 	// Amount : field : three
 	s.Amount = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MapWarp :: Warp EMF entity.
 type MapWarp struct {
+	byteSize int
+
 	DestinationMap    int
 	DestinationCoords protocol.Coords
 	LevelRequired     int
 	Door              int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapWarp) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapWarp) Serialize(writer *data.EoWriter) (err error) {
@@ -194,6 +228,7 @@ func (s *MapWarp) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// DestinationMap : field : short
 	s.DestinationMap = reader.GetShort()
 	// DestinationCoords : field : Coords
@@ -204,16 +239,24 @@ func (s *MapWarp) Deserialize(reader *data.EoReader) (err error) {
 	s.LevelRequired = reader.GetChar()
 	// Door : field : short
 	s.Door = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MapSign :: Sign EMF entity.
 type MapSign struct {
+	byteSize int
+
 	Coords           protocol.Coords
 	StringDataLength int
 	StringData       string
 	TitleLength      int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapSign) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapSign) Serialize(writer *data.EoWriter) (err error) {
@@ -243,6 +286,7 @@ func (s *MapSign) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
@@ -256,14 +300,22 @@ func (s *MapSign) Deserialize(reader *data.EoReader) (err error) {
 
 	// TitleLength : field : char
 	s.TitleLength = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MapTileSpecRowTile :: A single tile in a row of tilespecs.
 type MapTileSpecRowTile struct {
+	byteSize int
+
 	X        int
 	TileSpec MapTileSpec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapTileSpecRowTile) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapTileSpecRowTile) Serialize(writer *data.EoWriter) (err error) {
@@ -285,19 +337,28 @@ func (s *MapTileSpecRowTile) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// X : field : char
 	s.X = reader.GetChar()
 	// TileSpec : field : MapTileSpec
 	s.TileSpec = MapTileSpec(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MapTileSpecRow :: A row of tilespecs.
 type MapTileSpecRow struct {
+	byteSize int
+
 	Y          int
 	TilesCount int
 	Tiles      []MapTileSpecRowTile
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapTileSpecRow) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapTileSpecRow) Serialize(writer *data.EoWriter) (err error) {
@@ -326,6 +387,7 @@ func (s *MapTileSpecRow) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Y : field : char
 	s.Y = reader.GetChar()
 	// TilesCount : length : char
@@ -338,13 +400,22 @@ func (s *MapTileSpecRow) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // MapWarpRowTile :: A single tile in a row of warp entities.
 type MapWarpRowTile struct {
+	byteSize int
+
 	X    int
 	Warp MapWarp
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapWarpRowTile) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapWarpRowTile) Serialize(writer *data.EoWriter) (err error) {
@@ -366,21 +437,30 @@ func (s *MapWarpRowTile) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// X : field : char
 	s.X = reader.GetChar()
 	// Warp : field : MapWarp
 	if err = s.Warp.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MapWarpRow :: A row of warp entities.
 type MapWarpRow struct {
+	byteSize int
+
 	Y          int
 	TilesCount int
 	Tiles      []MapWarpRowTile
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapWarpRow) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapWarpRow) Serialize(writer *data.EoWriter) (err error) {
@@ -409,6 +489,7 @@ func (s *MapWarpRow) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Y : field : char
 	s.Y = reader.GetChar()
 	// TilesCount : length : char
@@ -421,13 +502,22 @@ func (s *MapWarpRow) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // MapGraphicRowTile :: A single tile in a row of map graphics.
 type MapGraphicRowTile struct {
+	byteSize int
+
 	X       int
 	Graphic int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapGraphicRowTile) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapGraphicRowTile) Serialize(writer *data.EoWriter) (err error) {
@@ -449,19 +539,28 @@ func (s *MapGraphicRowTile) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// X : field : char
 	s.X = reader.GetChar()
 	// Graphic : field : short
 	s.Graphic = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MapGraphicRow :: A row in a layer of map graphics.
 type MapGraphicRow struct {
+	byteSize int
+
 	Y          int
 	TilesCount int
 	Tiles      []MapGraphicRowTile
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapGraphicRow) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapGraphicRow) Serialize(writer *data.EoWriter) (err error) {
@@ -490,6 +589,7 @@ func (s *MapGraphicRow) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Y : field : char
 	s.Y = reader.GetChar()
 	// TilesCount : length : char
@@ -502,13 +602,22 @@ func (s *MapGraphicRow) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // MapGraphicLayer :: A layer of map graphics.
 type MapGraphicLayer struct {
+	byteSize int
+
 	GraphicRowsCount int
 	GraphicRows      []MapGraphicRow
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapGraphicLayer) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapGraphicLayer) Serialize(writer *data.EoWriter) (err error) {
@@ -533,6 +642,7 @@ func (s *MapGraphicLayer) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GraphicRowsCount : length : char
 	s.GraphicRowsCount = reader.GetChar()
 	// GraphicRows : array : MapGraphicRow
@@ -543,11 +653,15 @@ func (s *MapGraphicLayer) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // Emf :: Endless Map File.
 type Emf struct {
+	byteSize int
+
 	Rid            []int
 	Name           string
 	Type           MapType
@@ -576,6 +690,11 @@ type Emf struct {
 	GraphicLayers       []MapGraphicLayer //  The 9 layers of map graphics. Order is [Ground, Object, Overlay, Down Wall, Right Wall, Roof, Top, Shadow, Overlay2].
 	SignsCount          int
 	Signs               []MapSign
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *Emf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *Emf) Serialize(writer *data.EoWriter) (err error) {
@@ -741,6 +860,7 @@ func (s *Emf) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// EMF : field : string
 	if _, err = reader.GetFixedString(3); err != nil {
 		return
@@ -857,6 +977,8 @@ func (s *Emf) Deserialize(reader *data.EoReader) (err error) {
 			return
 		}
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }

--- a/pkg/eolib/protocol/net/client/packets_generated.go
+++ b/pkg/eolib/protocol/net/client/packets_generated.go
@@ -2930,6 +2930,11 @@ func (s *CitizenReplyClientPacket) Serialize(writer *data.EoWriter) (err error) 
 	writer.AddByte(255)
 	// Answers : array : string
 	for ndx := 0; ndx < 3; ndx++ {
+		if len(s.Answers) != 3 {
+			err = fmt.Errorf("expected Answers with length 3, got %d", len(s.Answers))
+			return
+		}
+
 		if ndx > 0 {
 			writer.AddByte(255)
 		}
@@ -5458,6 +5463,11 @@ func (s *GuildAgreeInfoTypeDataRanks) Serialize(writer *data.EoWriter) (err erro
 
 	// Ranks : array : string
 	for ndx := 0; ndx < 9; ndx++ {
+		if len(s.Ranks) != 9 {
+			err = fmt.Errorf("expected Ranks with length 9, got %d", len(s.Ranks))
+			return
+		}
+
 		if err = writer.AddString(s.Ranks[ndx]); err != nil {
 			return
 		}
@@ -5776,6 +5786,10 @@ func (s *GuildTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// GuildTag : field : string
+	if len(s.GuildTag) != 3 {
+		err = fmt.Errorf("expected GuildTag with length 3, got %d", len(s.GuildTag))
+		return
+	}
 	if err = writer.AddFixedString(s.GuildTag, 3); err != nil {
 		return
 	}

--- a/pkg/eolib/protocol/net/client/packets_generated.go
+++ b/pkg/eolib/protocol/net/client/packets_generated.go
@@ -4043,7 +4043,7 @@ func (s *RangeRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 		return
 	}
 	// NpcIndexes : array : char
-	for ndx := 0; ndx < reader.Remaining()/1; ndx++ {
+	for ndx := 0; reader.Remaining() > 0; ndx++ {
 		s.NpcIndexes = append(s.NpcIndexes, 0)
 		s.NpcIndexes[ndx] = reader.GetChar()
 	}
@@ -4509,6 +4509,9 @@ func (s *GuildAgreeInfoTypeDataRanks) Deserialize(reader *data.EoReader) (err er
 			return
 		}
 
+		if err = reader.NextChunk(); err != nil {
+			return
+		}
 	}
 
 	return

--- a/pkg/eolib/protocol/net/client/packets_generated.go
+++ b/pkg/eolib/protocol/net/client/packets_generated.go
@@ -4034,7 +4034,8 @@ func (s *RangeRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 
 	reader.SetIsChunked(true)
 	// PlayerIds : array : short
-	for ndx := 0; ndx < reader.Remaining()/2; ndx++ {
+	PlayerIdsRemaining := reader.Remaining()
+	for ndx := 0; ndx < PlayerIdsRemaining/2; ndx++ {
 		s.PlayerIds = append(s.PlayerIds, 0)
 		s.PlayerIds[ndx] = reader.GetShort()
 	}

--- a/pkg/eolib/protocol/net/client/packets_generated.go
+++ b/pkg/eolib/protocol/net/client/packets_generated.go
@@ -14,8 +14,7 @@ type InitInitClientPacket struct {
 	Challenge int
 	Version   net.Version
 
-	HdidLength int
-	Hdid       string
+	Hdid string
 }
 
 func (s InitInitClientPacket) Family() net.PacketFamily {
@@ -48,11 +47,11 @@ func (s *InitInitClientPacket) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// HdidLength : length : char
-	if err = writer.AddChar(s.HdidLength); err != nil {
+	if err = writer.AddChar(len(s.Hdid)); err != nil {
 		return
 	}
 	// Hdid : field : string
-	if err = writer.AddFixedString(s.Hdid, s.HdidLength); err != nil {
+	if err = writer.AddFixedString(s.Hdid, len(s.Hdid)); err != nil {
 		return
 	}
 	return
@@ -72,9 +71,9 @@ func (s *InitInitClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	// 112 : field : char
 	reader.GetChar()
 	// HdidLength : length : char
-	s.HdidLength = reader.GetChar()
+	hdidLength := reader.GetChar()
 	// Hdid : field : string
-	if s.Hdid, err = reader.GetFixedString(s.HdidLength); err != nil {
+	if s.Hdid, err = reader.GetFixedString(hdidLength); err != nil {
 		return
 	}
 
@@ -4979,8 +4978,6 @@ func (s *PlayerRangeRequestClientPacket) Deserialize(reader *data.EoReader) (err
 type NpcRangeRequestClientPacket struct {
 	byteSize int
 
-	NpcIndexesLength int
-
 	NpcIndexes []int
 }
 
@@ -5002,7 +4999,7 @@ func (s *NpcRangeRequestClientPacket) Serialize(writer *data.EoWriter) (err erro
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// NpcIndexesLength : length : char
-	if err = writer.AddChar(s.NpcIndexesLength); err != nil {
+	if err = writer.AddChar(len(s.NpcIndexes)); err != nil {
 		return
 	}
 	// 255 : field : byte
@@ -5010,7 +5007,7 @@ func (s *NpcRangeRequestClientPacket) Serialize(writer *data.EoWriter) (err erro
 		return
 	}
 	// NpcIndexes : array : char
-	for ndx := 0; ndx < s.NpcIndexesLength; ndx++ {
+	for ndx := 0; ndx < len(s.NpcIndexes); ndx++ {
 		if err = writer.AddChar(s.NpcIndexes[ndx]); err != nil {
 			return
 		}
@@ -5025,11 +5022,11 @@ func (s *NpcRangeRequestClientPacket) Deserialize(reader *data.EoReader) (err er
 
 	readerStartPosition := reader.Position()
 	// NpcIndexesLength : length : char
-	s.NpcIndexesLength = reader.GetChar()
+	npcIndexesLength := reader.GetChar()
 	// 255 : field : byte
 	reader.GetByte()
 	// NpcIndexes : array : char
-	for ndx := 0; ndx < s.NpcIndexesLength; ndx++ {
+	for ndx := 0; ndx < npcIndexesLength; ndx++ {
 		s.NpcIndexes = append(s.NpcIndexes, 0)
 		s.NpcIndexes[ndx] = reader.GetChar()
 	}

--- a/pkg/eolib/protocol/net/client/packets_generated.go
+++ b/pkg/eolib/protocol/net/client/packets_generated.go
@@ -9,6 +9,8 @@ import (
 
 // InitInitClientPacket ::  Connection initialization request. This packet is unencrypted.
 type InitInitClientPacket struct {
+	byteSize int
+
 	Challenge int
 	Version   net.Version
 
@@ -22,6 +24,11 @@ func (s InitInitClientPacket) Family() net.PacketFamily {
 
 func (s InitInitClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Init
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -55,6 +62,7 @@ func (s *InitInitClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Challenge : field : three
 	s.Challenge = reader.GetThree()
 	// Version : field : Version
@@ -70,11 +78,15 @@ func (s *InitInitClientPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // ConnectionAcceptClientPacket :: Confirm initialization data.
 type ConnectionAcceptClientPacket struct {
+	byteSize int
+
 	ClientEncryptionMultiple int
 	ServerEncryptionMultiple int
 	PlayerId                 int
@@ -86,6 +98,11 @@ func (s ConnectionAcceptClientPacket) Family() net.PacketFamily {
 
 func (s ConnectionAcceptClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ConnectionAcceptClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ConnectionAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -111,18 +128,21 @@ func (s *ConnectionAcceptClientPacket) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ClientEncryptionMultiple : field : short
 	s.ClientEncryptionMultiple = reader.GetShort()
 	// ServerEncryptionMultiple : field : short
 	s.ServerEncryptionMultiple = reader.GetShort()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ConnectionPingClientPacket :: Ping reply.
 type ConnectionPingClientPacket struct {
+	byteSize int
 }
 
 func (s ConnectionPingClientPacket) Family() net.PacketFamily {
@@ -131,6 +151,11 @@ func (s ConnectionPingClientPacket) Family() net.PacketFamily {
 
 func (s ConnectionPingClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Ping
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ConnectionPingClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ConnectionPingClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -148,16 +173,20 @@ func (s *ConnectionPingClientPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// k : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AccountRequestClientPacket :: Request creating an account.
 type AccountRequestClientPacket struct {
+	byteSize int
+
 	Username string
 }
 
@@ -167,6 +196,11 @@ func (s AccountRequestClientPacket) Family() net.PacketFamily {
 
 func (s AccountRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -184,16 +218,21 @@ func (s *AccountRequestClientPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Username : field : string
 	if s.Username, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AccountCreateClientPacket :: Confirm creating an account.
 type AccountCreateClientPacket struct {
+	byteSize int
+
 	SessionId int
 	Username  string
 	Password  string
@@ -210,6 +249,11 @@ func (s AccountCreateClientPacket) Family() net.PacketFamily {
 
 func (s AccountCreateClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Create
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountCreateClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountCreateClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -265,6 +309,7 @@ func (s *AccountCreateClientPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
@@ -328,12 +373,15 @@ func (s *AccountCreateClientPacket) Deserialize(reader *data.EoReader) (err erro
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AccountAgreeClientPacket :: Change password.
 type AccountAgreeClientPacket struct {
+	byteSize int
+
 	Username    string
 	OldPassword string
 	NewPassword string
@@ -345,6 +393,11 @@ func (s AccountAgreeClientPacket) Family() net.PacketFamily {
 
 func (s AccountAgreeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountAgreeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountAgreeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -375,6 +428,7 @@ func (s *AccountAgreeClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Username : field : string
 	if s.Username, err = reader.GetString(); err != nil {
@@ -401,12 +455,15 @@ func (s *AccountAgreeClientPacket) Deserialize(reader *data.EoReader) (err error
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterRequestClientPacket :: Request to create a character.
 type CharacterRequestClientPacket struct {
+	byteSize int
+
 	RequestString string
 }
 
@@ -416,6 +473,11 @@ func (s CharacterRequestClientPacket) Family() net.PacketFamily {
 
 func (s CharacterRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -436,6 +498,7 @@ func (s *CharacterRequestClientPacket) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// RequestString : field : string
 	if s.RequestString, err = reader.GetString(); err != nil {
@@ -446,12 +509,15 @@ func (s *CharacterRequestClientPacket) Deserialize(reader *data.EoReader) (err e
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterCreateClientPacket :: Confirm creating a character.
 type CharacterCreateClientPacket struct {
+	byteSize int
+
 	SessionId int
 	Gender    protocol.Gender
 	HairStyle int
@@ -466,6 +532,11 @@ func (s CharacterCreateClientPacket) Family() net.PacketFamily {
 
 func (s CharacterCreateClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Create
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterCreateClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterCreateClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -507,6 +578,7 @@ func (s *CharacterCreateClientPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
@@ -530,12 +602,15 @@ func (s *CharacterCreateClientPacket) Deserialize(reader *data.EoReader) (err er
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterTakeClientPacket :: Request to delete a character from an account.
 type CharacterTakeClientPacket struct {
+	byteSize int
+
 	CharacterId int
 }
 
@@ -545,6 +620,11 @@ func (s CharacterTakeClientPacket) Family() net.PacketFamily {
 
 func (s CharacterTakeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterTakeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -562,14 +642,18 @@ func (s *CharacterTakeClientPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CharacterId : field : int
 	s.CharacterId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterRemoveClientPacket :: Confirm deleting character from an account.
 type CharacterRemoveClientPacket struct {
+	byteSize int
+
 	SessionId   int
 	CharacterId int
 }
@@ -580,6 +664,11 @@ func (s CharacterRemoveClientPacket) Family() net.PacketFamily {
 
 func (s CharacterRemoveClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterRemoveClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -601,16 +690,20 @@ func (s *CharacterRemoveClientPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
 	// CharacterId : field : int
 	s.CharacterId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // LoginRequestClientPacket :: Login request.
 type LoginRequestClientPacket struct {
+	byteSize int
+
 	Username string
 	Password string
 }
@@ -621,6 +714,11 @@ func (s LoginRequestClientPacket) Family() net.PacketFamily {
 
 func (s LoginRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LoginRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LoginRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -646,6 +744,7 @@ func (s *LoginRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Username : field : string
 	if s.Username, err = reader.GetString(); err != nil {
@@ -664,12 +763,15 @@ func (s *LoginRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WelcomeRequestClientPacket :: Selected a character.
 type WelcomeRequestClientPacket struct {
+	byteSize int
+
 	CharacterId int
 }
 
@@ -679,6 +781,11 @@ func (s WelcomeRequestClientPacket) Family() net.PacketFamily {
 
 func (s WelcomeRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -696,14 +803,18 @@ func (s *WelcomeRequestClientPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CharacterId : field : int
 	s.CharacterId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WelcomeMsgClientPacket :: Entering game.
 type WelcomeMsgClientPacket struct {
+	byteSize int
+
 	SessionId   int
 	CharacterId int
 }
@@ -714,6 +825,11 @@ func (s WelcomeMsgClientPacket) Family() net.PacketFamily {
 
 func (s WelcomeMsgClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Msg
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeMsgClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeMsgClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -735,16 +851,20 @@ func (s *WelcomeMsgClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : three
 	s.SessionId = reader.GetThree()
 	// CharacterId : field : int
 	s.CharacterId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WelcomeAgreeClientPacket :: Requesting a file.
 type WelcomeAgreeClientPacket struct {
+	byteSize int
+
 	FileType     FileType
 	SessionId    int
 	FileTypeData WelcomeAgreeFileTypeData
@@ -755,7 +875,14 @@ type WelcomeAgreeFileTypeData interface {
 }
 
 type WelcomeAgreeFileTypeDataEmf struct {
+	byteSize int
+
 	FileId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeAgreeFileTypeDataEmf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeAgreeFileTypeDataEmf) Serialize(writer *data.EoWriter) (err error) {
@@ -773,14 +900,23 @@ func (s *WelcomeAgreeFileTypeDataEmf) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// FileId : field : short
 	s.FileId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type WelcomeAgreeFileTypeDataEif struct {
+	byteSize int
+
 	FileId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeAgreeFileTypeDataEif) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeAgreeFileTypeDataEif) Serialize(writer *data.EoWriter) (err error) {
@@ -798,14 +934,23 @@ func (s *WelcomeAgreeFileTypeDataEif) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// FileId : field : char
 	s.FileId = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type WelcomeAgreeFileTypeDataEnf struct {
+	byteSize int
+
 	FileId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeAgreeFileTypeDataEnf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeAgreeFileTypeDataEnf) Serialize(writer *data.EoWriter) (err error) {
@@ -823,14 +968,23 @@ func (s *WelcomeAgreeFileTypeDataEnf) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// FileId : field : char
 	s.FileId = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type WelcomeAgreeFileTypeDataEsf struct {
+	byteSize int
+
 	FileId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeAgreeFileTypeDataEsf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeAgreeFileTypeDataEsf) Serialize(writer *data.EoWriter) (err error) {
@@ -848,14 +1002,23 @@ func (s *WelcomeAgreeFileTypeDataEsf) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// FileId : field : char
 	s.FileId = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type WelcomeAgreeFileTypeDataEcf struct {
+	byteSize int
+
 	FileId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeAgreeFileTypeDataEcf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeAgreeFileTypeDataEcf) Serialize(writer *data.EoWriter) (err error) {
@@ -873,8 +1036,10 @@ func (s *WelcomeAgreeFileTypeDataEcf) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// FileId : field : char
 	s.FileId = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -885,6 +1050,11 @@ func (s WelcomeAgreeClientPacket) Family() net.PacketFamily {
 
 func (s WelcomeAgreeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeAgreeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeAgreeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -958,6 +1128,7 @@ func (s *WelcomeAgreeClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// FileType : field : FileType
 	s.FileType = FileType(reader.GetChar())
 	// SessionId : field : short
@@ -989,12 +1160,15 @@ func (s *WelcomeAgreeClientPacket) Deserialize(reader *data.EoReader) (err error
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AdminInteractTellClientPacket :: Talk to admin.
 type AdminInteractTellClientPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -1004,6 +1178,11 @@ func (s AdminInteractTellClientPacket) Family() net.PacketFamily {
 
 func (s AdminInteractTellClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Tell
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AdminInteractTellClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AdminInteractTellClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1021,16 +1200,21 @@ func (s *AdminInteractTellClientPacket) Deserialize(reader *data.EoReader) (err 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AdminInteractReportClientPacket :: Report character.
 type AdminInteractReportClientPacket struct {
+	byteSize int
+
 	Reportee string
 	Message  string
 }
@@ -1041,6 +1225,11 @@ func (s AdminInteractReportClientPacket) Family() net.PacketFamily {
 
 func (s AdminInteractReportClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Report
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AdminInteractReportClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AdminInteractReportClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1065,6 +1254,7 @@ func (s *AdminInteractReportClientPacket) Deserialize(reader *data.EoReader) (er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Reportee : field : string
 	if s.Reportee, err = reader.GetString(); err != nil {
@@ -1080,12 +1270,14 @@ func (s *AdminInteractReportClientPacket) Deserialize(reader *data.EoReader) (er
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GlobalRemoveClientPacket :: Enable whispers.
 type GlobalRemoveClientPacket struct {
+	byteSize int
 }
 
 func (s GlobalRemoveClientPacket) Family() net.PacketFamily {
@@ -1094,6 +1286,11 @@ func (s GlobalRemoveClientPacket) Family() net.PacketFamily {
 
 func (s GlobalRemoveClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GlobalRemoveClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GlobalRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1111,16 +1308,19 @@ func (s *GlobalRemoveClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// n : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GlobalPlayerClientPacket :: Disable whispers.
 type GlobalPlayerClientPacket struct {
+	byteSize int
 }
 
 func (s GlobalPlayerClientPacket) Family() net.PacketFamily {
@@ -1129,6 +1329,11 @@ func (s GlobalPlayerClientPacket) Family() net.PacketFamily {
 
 func (s GlobalPlayerClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GlobalPlayerClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GlobalPlayerClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1146,16 +1351,19 @@ func (s *GlobalPlayerClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// y : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GlobalOpenClientPacket :: Opened global tab.
 type GlobalOpenClientPacket struct {
+	byteSize int
 }
 
 func (s GlobalOpenClientPacket) Family() net.PacketFamily {
@@ -1164,6 +1372,11 @@ func (s GlobalOpenClientPacket) Family() net.PacketFamily {
 
 func (s GlobalOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GlobalOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GlobalOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1181,16 +1394,19 @@ func (s *GlobalOpenClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// y : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GlobalCloseClientPacket :: Closed global tab.
 type GlobalCloseClientPacket struct {
+	byteSize int
 }
 
 func (s GlobalCloseClientPacket) Family() net.PacketFamily {
@@ -1199,6 +1415,11 @@ func (s GlobalCloseClientPacket) Family() net.PacketFamily {
 
 func (s GlobalCloseClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Close
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GlobalCloseClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GlobalCloseClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1216,16 +1437,20 @@ func (s *GlobalCloseClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// n : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkRequestClientPacket :: Guild chat message.
 type TalkRequestClientPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -1235,6 +1460,11 @@ func (s TalkRequestClientPacket) Family() net.PacketFamily {
 
 func (s TalkRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1252,16 +1482,21 @@ func (s *TalkRequestClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkOpenClientPacket :: Party chat message.
 type TalkOpenClientPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -1271,6 +1506,11 @@ func (s TalkOpenClientPacket) Family() net.PacketFamily {
 
 func (s TalkOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1288,16 +1528,21 @@ func (s *TalkOpenClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkMsgClientPacket :: Global chat message.
 type TalkMsgClientPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -1307,6 +1552,11 @@ func (s TalkMsgClientPacket) Family() net.PacketFamily {
 
 func (s TalkMsgClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Msg
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkMsgClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkMsgClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1324,16 +1574,21 @@ func (s *TalkMsgClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkTellClientPacket :: Private chat message.
 type TalkTellClientPacket struct {
+	byteSize int
+
 	Name    string
 	Message string
 }
@@ -1344,6 +1599,11 @@ func (s TalkTellClientPacket) Family() net.PacketFamily {
 
 func (s TalkTellClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Tell
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkTellClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkTellClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1368,6 +1628,7 @@ func (s *TalkTellClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
@@ -1383,12 +1644,15 @@ func (s *TalkTellClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkReportClientPacket :: Public chat message.
 type TalkReportClientPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -1398,6 +1662,11 @@ func (s TalkReportClientPacket) Family() net.PacketFamily {
 
 func (s TalkReportClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Report
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkReportClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkReportClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1415,16 +1684,21 @@ func (s *TalkReportClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkPlayerClientPacket :: Public chat message - alias of TALK_REPORT (vestigial).
 type TalkPlayerClientPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -1434,6 +1708,11 @@ func (s TalkPlayerClientPacket) Family() net.PacketFamily {
 
 func (s TalkPlayerClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkPlayerClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkPlayerClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1451,16 +1730,21 @@ func (s *TalkPlayerClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkUseClientPacket :: Public chat message - alias of TALK_REPORT (vestigial).
 type TalkUseClientPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -1470,6 +1754,11 @@ func (s TalkUseClientPacket) Family() net.PacketFamily {
 
 func (s TalkUseClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkUseClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1487,16 +1776,21 @@ func (s *TalkUseClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkAdminClientPacket :: Admin chat message.
 type TalkAdminClientPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -1506,6 +1800,11 @@ func (s TalkAdminClientPacket) Family() net.PacketFamily {
 
 func (s TalkAdminClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Admin
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkAdminClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkAdminClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1523,16 +1822,21 @@ func (s *TalkAdminClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkAnnounceClientPacket :: Admin announcement.
 type TalkAnnounceClientPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -1542,6 +1846,11 @@ func (s TalkAnnounceClientPacket) Family() net.PacketFamily {
 
 func (s TalkAnnounceClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Announce
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkAnnounceClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkAnnounceClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1559,16 +1868,21 @@ func (s *TalkAnnounceClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AttackUseClientPacket :: Attacking.
 type AttackUseClientPacket struct {
+	byteSize int
+
 	Direction protocol.Direction
 	Timestamp int
 }
@@ -1579,6 +1893,11 @@ func (s AttackUseClientPacket) Family() net.PacketFamily {
 
 func (s AttackUseClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AttackUseClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AttackUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1600,16 +1919,20 @@ func (s *AttackUseClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
 	// Timestamp : field : three
 	s.Timestamp = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ChairRequestClientPacket :: Sitting on a chair.
 type ChairRequestClientPacket struct {
+	byteSize int
+
 	SitAction     SitAction
 	SitActionData ChairRequestSitActionData
 }
@@ -1619,7 +1942,14 @@ type ChairRequestSitActionData interface {
 }
 
 type ChairRequestSitActionDataSit struct {
+	byteSize int
+
 	Coords protocol.Coords
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChairRequestSitActionDataSit) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChairRequestSitActionDataSit) Serialize(writer *data.EoWriter) (err error) {
@@ -1637,10 +1967,12 @@ func (s *ChairRequestSitActionDataSit) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -1651,6 +1983,11 @@ func (s ChairRequestClientPacket) Family() net.PacketFamily {
 
 func (s ChairRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChairRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChairRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1680,6 +2017,7 @@ func (s *ChairRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SitAction : field : SitAction
 	s.SitAction = SitAction(reader.GetChar())
 	switch s.SitAction {
@@ -1689,12 +2027,15 @@ func (s *ChairRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SitRequestClientPacket :: Sit/stand request.
 type SitRequestClientPacket struct {
+	byteSize int
+
 	SitAction     SitAction
 	SitActionData SitRequestSitActionData
 }
@@ -1704,7 +2045,14 @@ type SitRequestSitActionData interface {
 }
 
 type SitRequestSitActionDataSit struct {
+	byteSize int
+
 	CursorCoords protocol.Coords // The coordinates of the map cursor.
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SitRequestSitActionDataSit) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SitRequestSitActionDataSit) Serialize(writer *data.EoWriter) (err error) {
@@ -1722,10 +2070,12 @@ func (s *SitRequestSitActionDataSit) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CursorCoords : field : Coords
 	if err = s.CursorCoords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -1736,6 +2086,11 @@ func (s SitRequestClientPacket) Family() net.PacketFamily {
 
 func (s SitRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SitRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SitRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1765,6 +2120,7 @@ func (s *SitRequestClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SitAction : field : SitAction
 	s.SitAction = SitAction(reader.GetChar())
 	switch s.SitAction {
@@ -1774,12 +2130,15 @@ func (s *SitRequestClientPacket) Deserialize(reader *data.EoReader) (err error) 
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EmoteReportClientPacket :: Doing an emote.
 type EmoteReportClientPacket struct {
+	byteSize int
+
 	Emote protocol.Emote
 }
 
@@ -1789,6 +2148,11 @@ func (s EmoteReportClientPacket) Family() net.PacketFamily {
 
 func (s EmoteReportClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Report
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EmoteReportClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EmoteReportClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1806,14 +2170,18 @@ func (s *EmoteReportClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Emote : field : Emote
 	s.Emote = protocol.Emote(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // FacePlayerClientPacket :: Facing a direction.
 type FacePlayerClientPacket struct {
+	byteSize int
+
 	Direction protocol.Direction
 }
 
@@ -1823,6 +2191,11 @@ func (s FacePlayerClientPacket) Family() net.PacketFamily {
 
 func (s FacePlayerClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *FacePlayerClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *FacePlayerClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1840,14 +2213,18 @@ func (s *FacePlayerClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WalkAdminClientPacket :: Walking with #nowall.
 type WalkAdminClientPacket struct {
+	byteSize int
+
 	WalkAction WalkAction
 }
 
@@ -1857,6 +2234,11 @@ func (s WalkAdminClientPacket) Family() net.PacketFamily {
 
 func (s WalkAdminClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Admin
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WalkAdminClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WalkAdminClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1874,16 +2256,20 @@ func (s *WalkAdminClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// WalkAction : field : WalkAction
 	if err = s.WalkAction.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WalkSpecClientPacket :: Walking through a player.
 type WalkSpecClientPacket struct {
+	byteSize int
+
 	WalkAction WalkAction
 }
 
@@ -1893,6 +2279,11 @@ func (s WalkSpecClientPacket) Family() net.PacketFamily {
 
 func (s WalkSpecClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Spec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WalkSpecClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WalkSpecClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1910,16 +2301,20 @@ func (s *WalkSpecClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// WalkAction : field : WalkAction
 	if err = s.WalkAction.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WalkPlayerClientPacket :: Walking.
 type WalkPlayerClientPacket struct {
+	byteSize int
+
 	WalkAction WalkAction
 }
 
@@ -1929,6 +2324,11 @@ func (s WalkPlayerClientPacket) Family() net.PacketFamily {
 
 func (s WalkPlayerClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WalkPlayerClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WalkPlayerClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1946,16 +2346,20 @@ func (s *WalkPlayerClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// WalkAction : field : WalkAction
 	if err = s.WalkAction.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BankOpenClientPacket :: Talked to a banker NPC.
 type BankOpenClientPacket struct {
+	byteSize int
+
 	NpcIndex int
 }
 
@@ -1965,6 +2369,11 @@ func (s BankOpenClientPacket) Family() net.PacketFamily {
 
 func (s BankOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BankOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BankOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1982,14 +2391,18 @@ func (s *BankOpenClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : short
 	s.NpcIndex = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BankAddClientPacket :: Depositing gold.
 type BankAddClientPacket struct {
+	byteSize int
+
 	Amount    int
 	SessionId int
 }
@@ -2000,6 +2413,11 @@ func (s BankAddClientPacket) Family() net.PacketFamily {
 
 func (s BankAddClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Add
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BankAddClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BankAddClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2021,16 +2439,20 @@ func (s *BankAddClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Amount : field : int
 	s.Amount = reader.GetInt()
 	// SessionId : field : three
 	s.SessionId = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BankTakeClientPacket :: Withdrawing gold.
 type BankTakeClientPacket struct {
+	byteSize int
+
 	Amount    int
 	SessionId int
 }
@@ -2041,6 +2463,11 @@ func (s BankTakeClientPacket) Family() net.PacketFamily {
 
 func (s BankTakeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BankTakeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BankTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2062,16 +2489,20 @@ func (s *BankTakeClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Amount : field : int
 	s.Amount = reader.GetInt()
 	// SessionId : field : three
 	s.SessionId = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BarberBuyClientPacket :: Purchasing a hair-style.
 type BarberBuyClientPacket struct {
+	byteSize int
+
 	HairStyle int
 	HairColor int
 	SessionId int
@@ -2083,6 +2514,11 @@ func (s BarberBuyClientPacket) Family() net.PacketFamily {
 
 func (s BarberBuyClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Buy
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BarberBuyClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BarberBuyClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2108,18 +2544,22 @@ func (s *BarberBuyClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// HairStyle : field : char
 	s.HairStyle = reader.GetChar()
 	// HairColor : field : char
 	s.HairColor = reader.GetChar()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BarberOpenClientPacket :: Talking to a barber NPC.
 type BarberOpenClientPacket struct {
+	byteSize int
+
 	NpcIndex int
 }
 
@@ -2129,6 +2569,11 @@ func (s BarberOpenClientPacket) Family() net.PacketFamily {
 
 func (s BarberOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BarberOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BarberOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2146,14 +2591,18 @@ func (s *BarberOpenClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : short
 	s.NpcIndex = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // LockerAddClientPacket :: Adding an item to a bank locker.
 type LockerAddClientPacket struct {
+	byteSize int
+
 	LockerCoords protocol.Coords
 	DepositItem  net.ThreeItem
 }
@@ -2164,6 +2613,11 @@ func (s LockerAddClientPacket) Family() net.PacketFamily {
 
 func (s LockerAddClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Add
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LockerAddClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LockerAddClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2185,6 +2639,7 @@ func (s *LockerAddClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// LockerCoords : field : Coords
 	if err = s.LockerCoords.Deserialize(reader); err != nil {
 		return
@@ -2193,12 +2648,15 @@ func (s *LockerAddClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.DepositItem.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // LockerTakeClientPacket :: Taking an item from a bank locker.
 type LockerTakeClientPacket struct {
+	byteSize int
+
 	LockerCoords protocol.Coords
 	TakeItemId   int
 }
@@ -2209,6 +2667,11 @@ func (s LockerTakeClientPacket) Family() net.PacketFamily {
 
 func (s LockerTakeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LockerTakeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LockerTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2230,18 +2693,22 @@ func (s *LockerTakeClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// LockerCoords : field : Coords
 	if err = s.LockerCoords.Deserialize(reader); err != nil {
 		return
 	}
 	// TakeItemId : field : short
 	s.TakeItemId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // LockerOpenClientPacket :: Opening a bank locker.
 type LockerOpenClientPacket struct {
+	byteSize int
+
 	LockerCoords protocol.Coords
 }
 
@@ -2251,6 +2718,11 @@ func (s LockerOpenClientPacket) Family() net.PacketFamily {
 
 func (s LockerOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LockerOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LockerOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2268,16 +2740,19 @@ func (s *LockerOpenClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// LockerCoords : field : Coords
 	if err = s.LockerCoords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // LockerBuyClientPacket :: Buying a locker space upgrade from a banker NPC.
 type LockerBuyClientPacket struct {
+	byteSize int
 }
 
 func (s LockerBuyClientPacket) Family() net.PacketFamily {
@@ -2286,6 +2761,11 @@ func (s LockerBuyClientPacket) Family() net.PacketFamily {
 
 func (s LockerBuyClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Buy
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LockerBuyClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LockerBuyClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2303,14 +2783,18 @@ func (s *LockerBuyClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 1 : dummy : char
 	reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CitizenRequestClientPacket :: Request sleeping at an inn.
 type CitizenRequestClientPacket struct {
+	byteSize int
+
 	SessionId  int
 	BehaviorId int
 }
@@ -2321,6 +2805,11 @@ func (s CitizenRequestClientPacket) Family() net.PacketFamily {
 
 func (s CitizenRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CitizenRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CitizenRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2342,16 +2831,20 @@ func (s *CitizenRequestClientPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
 	// BehaviorId : field : short
 	s.BehaviorId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CitizenAcceptClientPacket :: Confirm sleeping at an inn.
 type CitizenAcceptClientPacket struct {
+	byteSize int
+
 	SessionId  int
 	BehaviorId int
 }
@@ -2362,6 +2855,11 @@ func (s CitizenAcceptClientPacket) Family() net.PacketFamily {
 
 func (s CitizenAcceptClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CitizenAcceptClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CitizenAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2383,16 +2881,20 @@ func (s *CitizenAcceptClientPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
 	// BehaviorId : field : short
 	s.BehaviorId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CitizenReplyClientPacket :: Subscribing to a town.
 type CitizenReplyClientPacket struct {
+	byteSize int
+
 	SessionId  int
 	BehaviorId int
 	Answers    []string
@@ -2404,6 +2906,11 @@ func (s CitizenReplyClientPacket) Family() net.PacketFamily {
 
 func (s CitizenReplyClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CitizenReplyClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CitizenReplyClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2440,6 +2947,7 @@ func (s *CitizenReplyClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
@@ -2466,12 +2974,15 @@ func (s *CitizenReplyClientPacket) Deserialize(reader *data.EoReader) (err error
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CitizenRemoveClientPacket :: Giving up citizenship of a town.
 type CitizenRemoveClientPacket struct {
+	byteSize int
+
 	BehaviorId int
 }
 
@@ -2481,6 +2992,11 @@ func (s CitizenRemoveClientPacket) Family() net.PacketFamily {
 
 func (s CitizenRemoveClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CitizenRemoveClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CitizenRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2498,14 +3014,18 @@ func (s *CitizenRemoveClientPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// BehaviorId : field : short
 	s.BehaviorId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CitizenOpenClientPacket :: Talking to a citizenship NPC.
 type CitizenOpenClientPacket struct {
+	byteSize int
+
 	NpcIndex int
 }
 
@@ -2515,6 +3035,11 @@ func (s CitizenOpenClientPacket) Family() net.PacketFamily {
 
 func (s CitizenOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CitizenOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CitizenOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2532,14 +3057,18 @@ func (s *CitizenOpenClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : short
 	s.NpcIndex = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopCreateClientPacket :: Crafting an item from a shop.
 type ShopCreateClientPacket struct {
+	byteSize int
+
 	CraftItemId int
 	SessionId   int
 }
@@ -2550,6 +3079,11 @@ func (s ShopCreateClientPacket) Family() net.PacketFamily {
 
 func (s ShopCreateClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Create
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopCreateClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopCreateClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2571,16 +3105,20 @@ func (s *ShopCreateClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CraftItemId : field : short
 	s.CraftItemId = reader.GetShort()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopBuyClientPacket :: Purchasing an item from a shop.
 type ShopBuyClientPacket struct {
+	byteSize int
+
 	BuyItem   net.Item
 	SessionId int
 }
@@ -2591,6 +3129,11 @@ func (s ShopBuyClientPacket) Family() net.PacketFamily {
 
 func (s ShopBuyClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Buy
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopBuyClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopBuyClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2612,18 +3155,22 @@ func (s *ShopBuyClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// BuyItem : field : Item
 	if err = s.BuyItem.Deserialize(reader); err != nil {
 		return
 	}
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopSellClientPacket :: Selling an item to a shop.
 type ShopSellClientPacket struct {
+	byteSize int
+
 	SellItem  net.Item
 	SessionId int
 }
@@ -2634,6 +3181,11 @@ func (s ShopSellClientPacket) Family() net.PacketFamily {
 
 func (s ShopSellClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Sell
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopSellClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopSellClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2655,18 +3207,22 @@ func (s *ShopSellClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SellItem : field : Item
 	if err = s.SellItem.Deserialize(reader); err != nil {
 		return
 	}
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopOpenClientPacket :: Talking to a shop NPC.
 type ShopOpenClientPacket struct {
+	byteSize int
+
 	NpcIndex int
 }
 
@@ -2676,6 +3232,11 @@ func (s ShopOpenClientPacket) Family() net.PacketFamily {
 
 func (s ShopOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2693,14 +3254,18 @@ func (s *ShopOpenClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : short
 	s.NpcIndex = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillOpenClientPacket :: Talking to a skill master NPC.
 type StatSkillOpenClientPacket struct {
+	byteSize int
+
 	NpcIndex int
 }
 
@@ -2710,6 +3275,11 @@ func (s StatSkillOpenClientPacket) Family() net.PacketFamily {
 
 func (s StatSkillOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2727,14 +3297,18 @@ func (s *StatSkillOpenClientPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : short
 	s.NpcIndex = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillTakeClientPacket :: Learning a skill from a skill master NPC.
 type StatSkillTakeClientPacket struct {
+	byteSize int
+
 	SessionId int
 	SpellId   int
 }
@@ -2745,6 +3319,11 @@ func (s StatSkillTakeClientPacket) Family() net.PacketFamily {
 
 func (s StatSkillTakeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillTakeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2766,16 +3345,20 @@ func (s *StatSkillTakeClientPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillRemoveClientPacket :: Forgetting a skill at a skill master NPC.
 type StatSkillRemoveClientPacket struct {
+	byteSize int
+
 	SessionId int
 	SpellId   int
 }
@@ -2786,6 +3369,11 @@ func (s StatSkillRemoveClientPacket) Family() net.PacketFamily {
 
 func (s StatSkillRemoveClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillRemoveClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2807,16 +3395,20 @@ func (s *StatSkillRemoveClientPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillAddClientPacket :: Spending a stat point on a stat or skill.
 type StatSkillAddClientPacket struct {
+	byteSize int
+
 	ActionType     TrainType
 	ActionTypeData StatSkillAddActionTypeData
 }
@@ -2826,7 +3418,14 @@ type StatSkillAddActionTypeData interface {
 }
 
 type StatSkillAddActionTypeDataStat struct {
+	byteSize int
+
 	StatId StatId
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillAddActionTypeDataStat) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillAddActionTypeDataStat) Serialize(writer *data.EoWriter) (err error) {
@@ -2844,14 +3443,23 @@ func (s *StatSkillAddActionTypeDataStat) Deserialize(reader *data.EoReader) (err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// StatId : field : StatId
 	s.StatId = StatId(reader.GetShort())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type StatSkillAddActionTypeDataSkill struct {
+	byteSize int
+
 	SpellId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillAddActionTypeDataSkill) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillAddActionTypeDataSkill) Serialize(writer *data.EoWriter) (err error) {
@@ -2869,8 +3477,10 @@ func (s *StatSkillAddActionTypeDataSkill) Deserialize(reader *data.EoReader) (er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -2881,6 +3491,11 @@ func (s StatSkillAddClientPacket) Family() net.PacketFamily {
 
 func (s StatSkillAddClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Add
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillAddClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillAddClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2920,6 +3535,7 @@ func (s *StatSkillAddClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ActionType : field : TrainType
 	s.ActionType = TrainType(reader.GetChar())
 	switch s.ActionType {
@@ -2934,12 +3550,15 @@ func (s *StatSkillAddClientPacket) Deserialize(reader *data.EoReader) (err error
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillJunkClientPacket :: Resetting stats at a skill master.
 type StatSkillJunkClientPacket struct {
+	byteSize int
+
 	SessionId int
 }
 
@@ -2949,6 +3568,11 @@ func (s StatSkillJunkClientPacket) Family() net.PacketFamily {
 
 func (s StatSkillJunkClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Junk
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillJunkClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillJunkClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2966,14 +3590,18 @@ func (s *StatSkillJunkClientPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemUseClientPacket :: Using an item.
 type ItemUseClientPacket struct {
+	byteSize int
+
 	ItemId int
 }
 
@@ -2983,6 +3611,11 @@ func (s ItemUseClientPacket) Family() net.PacketFamily {
 
 func (s ItemUseClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemUseClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3000,14 +3633,18 @@ func (s *ItemUseClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemDropClientPacket :: Dropping items on the ground.
 type ItemDropClientPacket struct {
+	byteSize int
+
 	Item   net.ThreeItem
 	Coords ByteCoords //  The official client sends 255 byte values for the coords if an item is dropped via. the GUI button. 255 values here should be interpreted to mean "drop at current coords". Otherwise, the x and y fields contain encoded numbers that must be explicitly. decoded to get the actual x and y values.
 }
@@ -3018,6 +3655,11 @@ func (s ItemDropClientPacket) Family() net.PacketFamily {
 
 func (s ItemDropClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Drop
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemDropClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemDropClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3039,6 +3681,7 @@ func (s *ItemDropClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Item : field : ThreeItem
 	if err = s.Item.Deserialize(reader); err != nil {
 		return
@@ -3047,12 +3690,15 @@ func (s *ItemDropClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemJunkClientPacket :: Junking items.
 type ItemJunkClientPacket struct {
+	byteSize int
+
 	Item net.Item
 }
 
@@ -3062,6 +3708,11 @@ func (s ItemJunkClientPacket) Family() net.PacketFamily {
 
 func (s ItemJunkClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Junk
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemJunkClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemJunkClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3079,16 +3730,20 @@ func (s *ItemJunkClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Item : field : Item
 	if err = s.Item.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemGetClientPacket :: Taking items from the ground.
 type ItemGetClientPacket struct {
+	byteSize int
+
 	ItemIndex int
 }
 
@@ -3098,6 +3753,11 @@ func (s ItemGetClientPacket) Family() net.PacketFamily {
 
 func (s ItemGetClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Get
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemGetClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemGetClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3115,14 +3775,18 @@ func (s *ItemGetClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemIndex : field : short
 	s.ItemIndex = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BoardRemoveClientPacket :: Removing a post from a town board.
 type BoardRemoveClientPacket struct {
+	byteSize int
+
 	BoardId int
 	PostId  int
 }
@@ -3133,6 +3797,11 @@ func (s BoardRemoveClientPacket) Family() net.PacketFamily {
 
 func (s BoardRemoveClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BoardRemoveClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BoardRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3154,16 +3823,20 @@ func (s *BoardRemoveClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// BoardId : field : short
 	s.BoardId = reader.GetShort()
 	// PostId : field : short
 	s.PostId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BoardCreateClientPacket :: Posting a new message to a town board.
 type BoardCreateClientPacket struct {
+	byteSize int
+
 	BoardId     int
 	PostSubject string
 	PostBody    string
@@ -3175,6 +3848,11 @@ func (s BoardCreateClientPacket) Family() net.PacketFamily {
 
 func (s BoardCreateClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Create
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BoardCreateClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BoardCreateClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3205,6 +3883,7 @@ func (s *BoardCreateClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// BoardId : field : short
 	s.BoardId = reader.GetShort()
@@ -3228,12 +3907,15 @@ func (s *BoardCreateClientPacket) Deserialize(reader *data.EoReader) (err error)
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BoardTakeClientPacket :: Reading a post on a town board.
 type BoardTakeClientPacket struct {
+	byteSize int
+
 	BoardId int
 	PostId  int
 }
@@ -3244,6 +3926,11 @@ func (s BoardTakeClientPacket) Family() net.PacketFamily {
 
 func (s BoardTakeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BoardTakeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BoardTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3265,16 +3952,20 @@ func (s *BoardTakeClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// BoardId : field : short
 	s.BoardId = reader.GetShort()
 	// PostId : field : short
 	s.PostId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BoardOpenClientPacket :: Opening a town board.
 type BoardOpenClientPacket struct {
+	byteSize int
+
 	BoardId int
 }
 
@@ -3284,6 +3975,11 @@ func (s BoardOpenClientPacket) Family() net.PacketFamily {
 
 func (s BoardOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BoardOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BoardOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3301,14 +3997,18 @@ func (s *BoardOpenClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// BoardId : field : short
 	s.BoardId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // JukeboxOpenClientPacket :: Opening the jukebox listing.
 type JukeboxOpenClientPacket struct {
+	byteSize int
+
 	Coords protocol.Coords
 }
 
@@ -3318,6 +4018,11 @@ func (s JukeboxOpenClientPacket) Family() net.PacketFamily {
 
 func (s JukeboxOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *JukeboxOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *JukeboxOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3335,16 +4040,20 @@ func (s *JukeboxOpenClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // JukeboxMsgClientPacket :: Requesting a song on a jukebox.
 type JukeboxMsgClientPacket struct {
+	byteSize int
+
 	TrackId int // This value is 0-indexed.
 }
 
@@ -3354,6 +4063,11 @@ func (s JukeboxMsgClientPacket) Family() net.PacketFamily {
 
 func (s JukeboxMsgClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Msg
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *JukeboxMsgClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *JukeboxMsgClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3379,18 +4093,22 @@ func (s *JukeboxMsgClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 0 : field : char
 	reader.GetChar()
 	// 0 : field : char
 	reader.GetChar()
 	// TrackId : field : short
 	s.TrackId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // JukeboxUseClientPacket :: Playing a note with the bard skill.
 type JukeboxUseClientPacket struct {
+	byteSize int
+
 	InstrumentId int
 	NoteId       int
 }
@@ -3401,6 +4119,11 @@ func (s JukeboxUseClientPacket) Family() net.PacketFamily {
 
 func (s JukeboxUseClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *JukeboxUseClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *JukeboxUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3422,16 +4145,20 @@ func (s *JukeboxUseClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// InstrumentId : field : char
 	s.InstrumentId = reader.GetChar()
 	// NoteId : field : char
 	s.NoteId = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WarpAcceptClientPacket :: Accept a warp request from the server.
 type WarpAcceptClientPacket struct {
+	byteSize int
+
 	MapId     int
 	SessionId int
 }
@@ -3442,6 +4169,11 @@ func (s WarpAcceptClientPacket) Family() net.PacketFamily {
 
 func (s WarpAcceptClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WarpAcceptClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WarpAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3463,16 +4195,20 @@ func (s *WarpAcceptClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapId : field : short
 	s.MapId = reader.GetShort()
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WarpTakeClientPacket :: Request to download a copy of the map.
 type WarpTakeClientPacket struct {
+	byteSize int
+
 	MapId     int
 	SessionId int
 }
@@ -3483,6 +4219,11 @@ func (s WarpTakeClientPacket) Family() net.PacketFamily {
 
 func (s WarpTakeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WarpTakeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WarpTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3504,16 +4245,20 @@ func (s *WarpTakeClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapId : field : short
 	s.MapId = reader.GetShort()
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PaperdollRequestClientPacket :: Request for a player's paperdoll.
 type PaperdollRequestClientPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -3523,6 +4268,11 @@ func (s PaperdollRequestClientPacket) Family() net.PacketFamily {
 
 func (s PaperdollRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PaperdollRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PaperdollRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3540,14 +4290,18 @@ func (s *PaperdollRequestClientPacket) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PaperdollRemoveClientPacket :: Unequipping an item.
 type PaperdollRemoveClientPacket struct {
+	byteSize int
+
 	ItemId int
 	SubLoc int
 }
@@ -3558,6 +4312,11 @@ func (s PaperdollRemoveClientPacket) Family() net.PacketFamily {
 
 func (s PaperdollRemoveClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PaperdollRemoveClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PaperdollRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3579,16 +4338,20 @@ func (s *PaperdollRemoveClientPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
 	// SubLoc : field : char
 	s.SubLoc = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PaperdollAddClientPacket :: Equipping an item.
 type PaperdollAddClientPacket struct {
+	byteSize int
+
 	ItemId int
 	SubLoc int
 }
@@ -3599,6 +4362,11 @@ func (s PaperdollAddClientPacket) Family() net.PacketFamily {
 
 func (s PaperdollAddClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Add
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PaperdollAddClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PaperdollAddClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3620,16 +4388,20 @@ func (s *PaperdollAddClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
 	// SubLoc : field : char
 	s.SubLoc = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BookRequestClientPacket :: Request for a player's book.
 type BookRequestClientPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -3639,6 +4411,11 @@ func (s BookRequestClientPacket) Family() net.PacketFamily {
 
 func (s BookRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BookRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BookRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3656,14 +4433,17 @@ func (s *BookRequestClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MessagePingClientPacket :: #ping command request.
 type MessagePingClientPacket struct {
+	byteSize int
 }
 
 func (s MessagePingClientPacket) Family() net.PacketFamily {
@@ -3672,6 +4452,11 @@ func (s MessagePingClientPacket) Family() net.PacketFamily {
 
 func (s MessagePingClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Ping
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MessagePingClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MessagePingClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3689,14 +4474,18 @@ func (s *MessagePingClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 2 : dummy : short
 	reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersAcceptClientPacket :: #find command request.
 type PlayersAcceptClientPacket struct {
+	byteSize int
+
 	Name string
 }
 
@@ -3706,6 +4495,11 @@ func (s PlayersAcceptClientPacket) Family() net.PacketFamily {
 
 func (s PlayersAcceptClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersAcceptClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3723,16 +4517,20 @@ func (s *PlayersAcceptClientPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersRequestClientPacket :: Requesting a list of online players.
 type PlayersRequestClientPacket struct {
+	byteSize int
 }
 
 func (s PlayersRequestClientPacket) Family() net.PacketFamily {
@@ -3741,6 +4539,11 @@ func (s PlayersRequestClientPacket) Family() net.PacketFamily {
 
 func (s PlayersRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3758,14 +4561,17 @@ func (s *PlayersRequestClientPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 255 : dummy : byte
 	reader.GetByte()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersListClientPacket :: Requesting a list of online friends.
 type PlayersListClientPacket struct {
+	byteSize int
 }
 
 func (s PlayersListClientPacket) Family() net.PacketFamily {
@@ -3774,6 +4580,11 @@ func (s PlayersListClientPacket) Family() net.PacketFamily {
 
 func (s PlayersListClientPacket) Action() net.PacketAction {
 	return net.PacketAction_List
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersListClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersListClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3791,14 +4602,18 @@ func (s *PlayersListClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 255 : dummy : byte
 	reader.GetByte()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // DoorOpenClientPacket :: Opening a door.
 type DoorOpenClientPacket struct {
+	byteSize int
+
 	Coords protocol.Coords
 }
 
@@ -3808,6 +4623,11 @@ func (s DoorOpenClientPacket) Family() net.PacketFamily {
 
 func (s DoorOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *DoorOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *DoorOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3825,16 +4645,20 @@ func (s *DoorOpenClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ChestOpenClientPacket :: Opening a chest.
 type ChestOpenClientPacket struct {
+	byteSize int
+
 	Coords protocol.Coords
 }
 
@@ -3844,6 +4668,11 @@ func (s ChestOpenClientPacket) Family() net.PacketFamily {
 
 func (s ChestOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChestOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChestOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3861,16 +4690,20 @@ func (s *ChestOpenClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ChestAddClientPacket :: Placing an item in to a chest.
 type ChestAddClientPacket struct {
+	byteSize int
+
 	Coords  protocol.Coords
 	AddItem net.ThreeItem
 }
@@ -3881,6 +4714,11 @@ func (s ChestAddClientPacket) Family() net.PacketFamily {
 
 func (s ChestAddClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Add
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChestAddClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChestAddClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3902,6 +4740,7 @@ func (s *ChestAddClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
@@ -3910,12 +4749,15 @@ func (s *ChestAddClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.AddItem.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ChestTakeClientPacket :: Taking an item from a chest.
 type ChestTakeClientPacket struct {
+	byteSize int
+
 	Coords     protocol.Coords
 	TakeItemId int
 }
@@ -3926,6 +4768,11 @@ func (s ChestTakeClientPacket) Family() net.PacketFamily {
 
 func (s ChestTakeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChestTakeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChestTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3947,18 +4794,21 @@ func (s *ChestTakeClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
 	// TakeItemId : field : short
 	s.TakeItemId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // RefreshRequestClientPacket :: Requesting new info about nearby objects.
 type RefreshRequestClientPacket struct {
+	byteSize int
 }
 
 func (s RefreshRequestClientPacket) Family() net.PacketFamily {
@@ -3967,6 +4817,11 @@ func (s RefreshRequestClientPacket) Family() net.PacketFamily {
 
 func (s RefreshRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *RefreshRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *RefreshRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3984,14 +4839,18 @@ func (s *RefreshRequestClientPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 255 : dummy : byte
 	reader.GetByte()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // RangeRequestClientPacket :: Requesting info about nearby players and NPCs.
 type RangeRequestClientPacket struct {
+	byteSize int
+
 	PlayerIds  []int
 	NpcIndexes []int
 }
@@ -4002,6 +4861,11 @@ func (s RangeRequestClientPacket) Family() net.PacketFamily {
 
 func (s RangeRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *RangeRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *RangeRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4032,6 +4896,7 @@ func (s *RangeRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayerIds : array : short
 	PlayerIdsRemaining := reader.Remaining()
@@ -4050,12 +4915,15 @@ func (s *RangeRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayerRangeRequestClientPacket :: Requesting info about nearby players.
 type PlayerRangeRequestClientPacket struct {
+	byteSize int
+
 	PlayerIds []int
 }
 
@@ -4065,6 +4933,11 @@ func (s PlayerRangeRequestClientPacket) Family() net.PacketFamily {
 
 func (s PlayerRangeRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayerRangeRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayerRangeRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4085,17 +4958,22 @@ func (s *PlayerRangeRequestClientPacket) Deserialize(reader *data.EoReader) (err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerIds : array : short
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
 		s.PlayerIds = append(s.PlayerIds, 0)
 		s.PlayerIds[ndx] = reader.GetShort()
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // NpcRangeRequestClientPacket :: Requesting info about nearby NPCs.
 type NpcRangeRequestClientPacket struct {
+	byteSize int
+
 	NpcIndexesLength int
 
 	NpcIndexes []int
@@ -4107,6 +4985,11 @@ func (s NpcRangeRequestClientPacket) Family() net.PacketFamily {
 
 func (s NpcRangeRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcRangeRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcRangeRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4135,6 +5018,7 @@ func (s *NpcRangeRequestClientPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndexesLength : length : char
 	s.NpcIndexesLength = reader.GetChar()
 	// 255 : field : byte
@@ -4145,11 +5029,15 @@ func (s *NpcRangeRequestClientPacket) Deserialize(reader *data.EoReader) (err er
 		s.NpcIndexes[ndx] = reader.GetChar()
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // PartyRequestClientPacket :: Send party invite / join request.
 type PartyRequestClientPacket struct {
+	byteSize int
+
 	RequestType net.PartyRequestType
 	PlayerId    int
 }
@@ -4160,6 +5048,11 @@ func (s PartyRequestClientPacket) Family() net.PacketFamily {
 
 func (s PartyRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4181,16 +5074,20 @@ func (s *PartyRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// RequestType : field : PartyRequestType
 	s.RequestType = net.PartyRequestType(reader.GetChar())
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyAcceptClientPacket :: Accept party invite / join request.
 type PartyAcceptClientPacket struct {
+	byteSize int
+
 	RequestType     net.PartyRequestType
 	InviterPlayerId int
 }
@@ -4201,6 +5098,11 @@ func (s PartyAcceptClientPacket) Family() net.PacketFamily {
 
 func (s PartyAcceptClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyAcceptClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4222,16 +5124,20 @@ func (s *PartyAcceptClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// RequestType : field : PartyRequestType
 	s.RequestType = net.PartyRequestType(reader.GetChar())
 	// InviterPlayerId : field : short
 	s.InviterPlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyRemoveClientPacket :: Remove player from a party.
 type PartyRemoveClientPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -4241,6 +5147,11 @@ func (s PartyRemoveClientPacket) Family() net.PacketFamily {
 
 func (s PartyRemoveClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyRemoveClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4258,14 +5169,18 @@ func (s *PartyRemoveClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyTakeClientPacket :: Request updated party info.
 type PartyTakeClientPacket struct {
+	byteSize int
+
 	MembersCount int
 }
 
@@ -4275,6 +5190,11 @@ func (s PartyTakeClientPacket) Family() net.PacketFamily {
 
 func (s PartyTakeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyTakeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4292,14 +5212,18 @@ func (s *PartyTakeClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MembersCount : field : char
 	s.MembersCount = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildRequestClientPacket :: Requested to create a guild.
 type GuildRequestClientPacket struct {
+	byteSize int
+
 	SessionId int
 	GuildTag  string
 	GuildName string
@@ -4311,6 +5235,11 @@ func (s GuildRequestClientPacket) Family() net.PacketFamily {
 
 func (s GuildRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4341,6 +5270,7 @@ func (s *GuildRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
@@ -4364,12 +5294,15 @@ func (s *GuildRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildAcceptClientPacket :: Accept pending guild creation invite.
 type GuildAcceptClientPacket struct {
+	byteSize int
+
 	InviterPlayerId int
 }
 
@@ -4379,6 +5312,11 @@ func (s GuildAcceptClientPacket) Family() net.PacketFamily {
 
 func (s GuildAcceptClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildAcceptClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4400,16 +5338,20 @@ func (s *GuildAcceptClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 20202 : field : int
 	reader.GetInt()
 	// InviterPlayerId : field : short
 	s.InviterPlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildRemoveClientPacket :: Leave guild.
 type GuildRemoveClientPacket struct {
+	byteSize int
+
 	SessionId int
 }
 
@@ -4419,6 +5361,11 @@ func (s GuildRemoveClientPacket) Family() net.PacketFamily {
 
 func (s GuildRemoveClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildRemoveClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4436,14 +5383,18 @@ func (s *GuildRemoveClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildAgreeClientPacket :: Update the guild description or rank list.
 type GuildAgreeClientPacket struct {
+	byteSize int
+
 	SessionId    int
 	InfoType     GuildInfoType
 	InfoTypeData GuildAgreeInfoTypeData
@@ -4454,7 +5405,14 @@ type GuildAgreeInfoTypeData interface {
 }
 
 type GuildAgreeInfoTypeDataDescription struct {
+	byteSize int
+
 	Description string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildAgreeInfoTypeDataDescription) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildAgreeInfoTypeDataDescription) Serialize(writer *data.EoWriter) (err error) {
@@ -4472,16 +5430,26 @@ func (s *GuildAgreeInfoTypeDataDescription) Deserialize(reader *data.EoReader) (
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Description : field : string
 	if s.Description, err = reader.GetString(); err != nil {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 type GuildAgreeInfoTypeDataRanks struct {
+	byteSize int
+
 	Ranks []string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildAgreeInfoTypeDataRanks) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildAgreeInfoTypeDataRanks) Serialize(writer *data.EoWriter) (err error) {
@@ -4503,6 +5471,7 @@ func (s *GuildAgreeInfoTypeDataRanks) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Ranks : array : string
 	for ndx := 0; ndx < 9; ndx++ {
 		s.Ranks = append(s.Ranks, "")
@@ -4515,6 +5484,8 @@ func (s *GuildAgreeInfoTypeDataRanks) Deserialize(reader *data.EoReader) (err er
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
@@ -4524,6 +5495,11 @@ func (s GuildAgreeClientPacket) Family() net.PacketFamily {
 
 func (s GuildAgreeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildAgreeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildAgreeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4569,6 +5545,7 @@ func (s *GuildAgreeClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
@@ -4587,12 +5564,15 @@ func (s *GuildAgreeClientPacket) Deserialize(reader *data.EoReader) (err error) 
 		}
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildCreateClientPacket :: Final confirm creating a guild.
 type GuildCreateClientPacket struct {
+	byteSize int
+
 	SessionId   int
 	GuildTag    string
 	GuildName   string
@@ -4605,6 +5585,11 @@ func (s GuildCreateClientPacket) Family() net.PacketFamily {
 
 func (s GuildCreateClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Create
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildCreateClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildCreateClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4640,6 +5625,7 @@ func (s *GuildCreateClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
@@ -4671,12 +5657,15 @@ func (s *GuildCreateClientPacket) Deserialize(reader *data.EoReader) (err error)
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildPlayerClientPacket :: Request to join a guild.
 type GuildPlayerClientPacket struct {
+	byteSize int
+
 	SessionId     int
 	GuildTag      string
 	RecruiterName string
@@ -4688,6 +5677,11 @@ func (s GuildPlayerClientPacket) Family() net.PacketFamily {
 
 func (s GuildPlayerClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildPlayerClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildPlayerClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4718,6 +5712,7 @@ func (s *GuildPlayerClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
@@ -4741,12 +5736,15 @@ func (s *GuildPlayerClientPacket) Deserialize(reader *data.EoReader) (err error)
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildTakeClientPacket :: Request guild description, rank list, or bank balance.
 type GuildTakeClientPacket struct {
+	byteSize int
+
 	SessionId int
 	InfoType  GuildInfoType
 	GuildTag  string
@@ -4758,6 +5756,11 @@ func (s GuildTakeClientPacket) Family() net.PacketFamily {
 
 func (s GuildTakeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildTakeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildTakeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4783,6 +5786,7 @@ func (s *GuildTakeClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
 	// InfoType : field : GuildInfoType
@@ -4792,11 +5796,15 @@ func (s *GuildTakeClientPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // GuildUseClientPacket :: Accepted a join request.
 type GuildUseClientPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -4806,6 +5814,11 @@ func (s GuildUseClientPacket) Family() net.PacketFamily {
 
 func (s GuildUseClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildUseClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4823,14 +5836,18 @@ func (s *GuildUseClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildBuyClientPacket :: Deposit gold in to the guild bank.
 type GuildBuyClientPacket struct {
+	byteSize int
+
 	SessionId  int
 	GoldAmount int
 }
@@ -4841,6 +5858,11 @@ func (s GuildBuyClientPacket) Family() net.PacketFamily {
 
 func (s GuildBuyClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Buy
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildBuyClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildBuyClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4862,16 +5884,20 @@ func (s *GuildBuyClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildOpenClientPacket :: Talking to a guild master NPC.
 type GuildOpenClientPacket struct {
+	byteSize int
+
 	NpcIndex int
 }
 
@@ -4881,6 +5907,11 @@ func (s GuildOpenClientPacket) Family() net.PacketFamily {
 
 func (s GuildOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4898,14 +5929,18 @@ func (s *GuildOpenClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : short
 	s.NpcIndex = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildTellClientPacket :: Requested member list of a guild.
 type GuildTellClientPacket struct {
+	byteSize int
+
 	SessionId     int
 	GuildIdentity string
 }
@@ -4916,6 +5951,11 @@ func (s GuildTellClientPacket) Family() net.PacketFamily {
 
 func (s GuildTellClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Tell
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildTellClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildTellClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4937,6 +5977,7 @@ func (s *GuildTellClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
 	// GuildIdentity : field : string
@@ -4944,11 +5985,15 @@ func (s *GuildTellClientPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // GuildReportClientPacket :: Requested general information of a guild.
 type GuildReportClientPacket struct {
+	byteSize int
+
 	SessionId     int
 	GuildIdentity string
 }
@@ -4959,6 +6004,11 @@ func (s GuildReportClientPacket) Family() net.PacketFamily {
 
 func (s GuildReportClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Report
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildReportClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildReportClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4980,6 +6030,7 @@ func (s *GuildReportClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
 	// GuildIdentity : field : string
@@ -4987,11 +6038,15 @@ func (s *GuildReportClientPacket) Deserialize(reader *data.EoReader) (err error)
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // GuildJunkClientPacket :: Disband guild.
 type GuildJunkClientPacket struct {
+	byteSize int
+
 	SessionId int
 }
 
@@ -5001,6 +6056,11 @@ func (s GuildJunkClientPacket) Family() net.PacketFamily {
 
 func (s GuildJunkClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Junk
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildJunkClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildJunkClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5018,14 +6078,18 @@ func (s *GuildJunkClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildKickClientPacket :: Kick member from guild.
 type GuildKickClientPacket struct {
+	byteSize int
+
 	SessionId  int
 	MemberName string
 }
@@ -5036,6 +6100,11 @@ func (s GuildKickClientPacket) Family() net.PacketFamily {
 
 func (s GuildKickClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Kick
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildKickClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildKickClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5057,6 +6126,7 @@ func (s *GuildKickClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
 	// MemberName : field : string
@@ -5064,11 +6134,15 @@ func (s *GuildKickClientPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // GuildRankClientPacket :: Update a member's rank.
 type GuildRankClientPacket struct {
+	byteSize int
+
 	SessionId  int
 	Rank       int
 	MemberName string
@@ -5080,6 +6154,11 @@ func (s GuildRankClientPacket) Family() net.PacketFamily {
 
 func (s GuildRankClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Rank
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildRankClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildRankClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5105,6 +6184,7 @@ func (s *GuildRankClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
 	// Rank : field : char
@@ -5114,11 +6194,15 @@ func (s *GuildRankClientPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // SpellRequestClientPacket :: Begin spell chanting.
 type SpellRequestClientPacket struct {
+	byteSize int
+
 	SpellId   int
 	Timestamp int
 }
@@ -5129,6 +6213,11 @@ func (s SpellRequestClientPacket) Family() net.PacketFamily {
 
 func (s SpellRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5150,16 +6239,20 @@ func (s *SpellRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
 	// Timestamp : field : three
 	s.Timestamp = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SpellTargetSelfClientPacket :: Self-targeted spell cast.
 type SpellTargetSelfClientPacket struct {
+	byteSize int
+
 	Direction protocol.Direction
 	SpellId   int
 	Timestamp int
@@ -5171,6 +6264,11 @@ func (s SpellTargetSelfClientPacket) Family() net.PacketFamily {
 
 func (s SpellTargetSelfClientPacket) Action() net.PacketAction {
 	return net.PacketAction_TargetSelf
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellTargetSelfClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellTargetSelfClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5196,18 +6294,22 @@ func (s *SpellTargetSelfClientPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
 	// Timestamp : field : three
 	s.Timestamp = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SpellTargetOtherClientPacket :: Targeted spell cast.
 type SpellTargetOtherClientPacket struct {
+	byteSize int
+
 	TargetType        SpellTargetType
 	PreviousTimestamp int
 	SpellId           int
@@ -5221,6 +6323,11 @@ func (s SpellTargetOtherClientPacket) Family() net.PacketFamily {
 
 func (s SpellTargetOtherClientPacket) Action() net.PacketAction {
 	return net.PacketAction_TargetOther
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellTargetOtherClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellTargetOtherClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5254,6 +6361,7 @@ func (s *SpellTargetOtherClientPacket) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// TargetType : field : SpellTargetType
 	s.TargetType = SpellTargetType(reader.GetChar())
 	// PreviousTimestamp : field : three
@@ -5264,12 +6372,15 @@ func (s *SpellTargetOtherClientPacket) Deserialize(reader *data.EoReader) (err e
 	s.VictimId = reader.GetShort()
 	// Timestamp : field : three
 	s.Timestamp = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SpellTargetGroupClientPacket :: Group spell cast.
 type SpellTargetGroupClientPacket struct {
+	byteSize int
+
 	SpellId   int
 	Timestamp int
 }
@@ -5280,6 +6391,11 @@ func (s SpellTargetGroupClientPacket) Family() net.PacketFamily {
 
 func (s SpellTargetGroupClientPacket) Action() net.PacketAction {
 	return net.PacketAction_TargetGroup
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellTargetGroupClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellTargetGroupClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5301,16 +6417,20 @@ func (s *SpellTargetGroupClientPacket) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
 	// Timestamp : field : three
 	s.Timestamp = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SpellUseClientPacket :: Raise arm to cast a spell (vestigial).
 type SpellUseClientPacket struct {
+	byteSize int
+
 	Direction protocol.Direction
 }
 
@@ -5320,6 +6440,11 @@ func (s SpellUseClientPacket) Family() net.PacketFamily {
 
 func (s SpellUseClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellUseClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5337,14 +6462,18 @@ func (s *SpellUseClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeRequestClientPacket :: Requesting a trade with another player.
 type TradeRequestClientPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -5354,6 +6483,11 @@ func (s TradeRequestClientPacket) Family() net.PacketFamily {
 
 func (s TradeRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5375,16 +6509,20 @@ func (s *TradeRequestClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 138 : field : char
 	reader.GetChar()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeAcceptClientPacket :: Accepting a trade request.
 type TradeAcceptClientPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -5394,6 +6532,11 @@ func (s TradeAcceptClientPacket) Family() net.PacketFamily {
 
 func (s TradeAcceptClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeAcceptClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5415,16 +6558,20 @@ func (s *TradeAcceptClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 0 : field : char
 	reader.GetChar()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeRemoveClientPacket :: Remove an item from the trade screen.
 type TradeRemoveClientPacket struct {
+	byteSize int
+
 	ItemId int
 }
 
@@ -5434,6 +6581,11 @@ func (s TradeRemoveClientPacket) Family() net.PacketFamily {
 
 func (s TradeRemoveClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeRemoveClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeRemoveClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5451,14 +6603,18 @@ func (s *TradeRemoveClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeAgreeClientPacket :: Mark trade as agreed.
 type TradeAgreeClientPacket struct {
+	byteSize int
+
 	Agree bool
 }
 
@@ -5468,6 +6624,11 @@ func (s TradeAgreeClientPacket) Family() net.PacketFamily {
 
 func (s TradeAgreeClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeAgreeClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeAgreeClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5491,18 +6652,22 @@ func (s *TradeAgreeClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Agree : field : bool
 	if boolVal := reader.GetChar(); boolVal > 0 {
 		s.Agree = true
 	} else {
 		s.Agree = false
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeAddClientPacket :: Add an item to the trade screen.
 type TradeAddClientPacket struct {
+	byteSize int
+
 	AddItem net.Item
 }
 
@@ -5512,6 +6677,11 @@ func (s TradeAddClientPacket) Family() net.PacketFamily {
 
 func (s TradeAddClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Add
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeAddClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeAddClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5529,16 +6699,19 @@ func (s *TradeAddClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// AddItem : field : Item
 	if err = s.AddItem.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeCloseClientPacket :: Cancel the trade.
 type TradeCloseClientPacket struct {
+	byteSize int
 }
 
 func (s TradeCloseClientPacket) Family() net.PacketFamily {
@@ -5547,6 +6720,11 @@ func (s TradeCloseClientPacket) Family() net.PacketFamily {
 
 func (s TradeCloseClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Close
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeCloseClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeCloseClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5564,14 +6742,18 @@ func (s *TradeCloseClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 0 : dummy : char
 	reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // QuestUseClientPacket :: Talking to a quest NPC.
 type QuestUseClientPacket struct {
+	byteSize int
+
 	NpcIndex int
 	QuestId  int //  Quest ID is 0 unless the player explicitly selects a quest from the quest switcher.
 }
@@ -5582,6 +6764,11 @@ func (s QuestUseClientPacket) Family() net.PacketFamily {
 
 func (s QuestUseClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *QuestUseClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *QuestUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5603,16 +6790,20 @@ func (s *QuestUseClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : short
 	s.NpcIndex = reader.GetShort()
 	// QuestId : field : short
 	s.QuestId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // QuestAcceptClientPacket :: Response to a quest NPC dialog.
 type QuestAcceptClientPacket struct {
+	byteSize int
+
 	SessionId     int
 	DialogId      int
 	QuestId       int
@@ -5626,7 +6817,14 @@ type QuestAcceptReplyTypeData interface {
 }
 
 type QuestAcceptReplyTypeDataLink struct {
+	byteSize int
+
 	Action int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *QuestAcceptReplyTypeDataLink) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *QuestAcceptReplyTypeDataLink) Serialize(writer *data.EoWriter) (err error) {
@@ -5644,8 +6842,10 @@ func (s *QuestAcceptReplyTypeDataLink) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Action : field : char
 	s.Action = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -5656,6 +6856,11 @@ func (s QuestAcceptClientPacket) Family() net.PacketFamily {
 
 func (s QuestAcceptClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *QuestAcceptClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *QuestAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5701,6 +6906,7 @@ func (s *QuestAcceptClientPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
 	// DialogId : field : short
@@ -5718,12 +6924,15 @@ func (s *QuestAcceptClientPacket) Deserialize(reader *data.EoReader) (err error)
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // QuestListClientPacket :: Quest history / progress request.
 type QuestListClientPacket struct {
+	byteSize int
+
 	Page net.QuestPage
 }
 
@@ -5733,6 +6942,11 @@ func (s QuestListClientPacket) Family() net.PacketFamily {
 
 func (s QuestListClientPacket) Action() net.PacketAction {
 	return net.PacketAction_List
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *QuestListClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *QuestListClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5750,14 +6964,18 @@ func (s *QuestListClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Page : field : QuestPage
 	s.Page = net.QuestPage(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MarriageOpenClientPacket :: Talking to a law NPC.
 type MarriageOpenClientPacket struct {
+	byteSize int
+
 	NpcIndex int
 }
 
@@ -5767,6 +6985,11 @@ func (s MarriageOpenClientPacket) Family() net.PacketFamily {
 
 func (s MarriageOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MarriageOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MarriageOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5784,14 +7007,18 @@ func (s *MarriageOpenClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : short
 	s.NpcIndex = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MarriageRequestClientPacket :: Requesting marriage approval.
 type MarriageRequestClientPacket struct {
+	byteSize int
+
 	RequestType MarriageRequestType
 	SessionId   int
 	Name        string
@@ -5803,6 +7030,11 @@ func (s MarriageRequestClientPacket) Family() net.PacketFamily {
 
 func (s MarriageRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MarriageRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MarriageRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5831,6 +7063,7 @@ func (s *MarriageRequestClientPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// RequestType : field : MarriageRequestType
 	s.RequestType = MarriageRequestType(reader.GetChar())
@@ -5845,12 +7078,15 @@ func (s *MarriageRequestClientPacket) Deserialize(reader *data.EoReader) (err er
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PriestAcceptClientPacket :: Accepting a marriage request.
 type PriestAcceptClientPacket struct {
+	byteSize int
+
 	SessionId int
 }
 
@@ -5860,6 +7096,11 @@ func (s PriestAcceptClientPacket) Family() net.PacketFamily {
 
 func (s PriestAcceptClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PriestAcceptClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PriestAcceptClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5877,14 +7118,18 @@ func (s *PriestAcceptClientPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PriestOpenClientPacket :: Talking to a priest NPC.
 type PriestOpenClientPacket struct {
+	byteSize int
+
 	NpcIndex int
 }
 
@@ -5894,6 +7139,11 @@ func (s PriestOpenClientPacket) Family() net.PacketFamily {
 
 func (s PriestOpenClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PriestOpenClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PriestOpenClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5911,14 +7161,18 @@ func (s *PriestOpenClientPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : int
 	s.NpcIndex = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PriestRequestClientPacket :: Requesting marriage at a priest.
 type PriestRequestClientPacket struct {
+	byteSize int
+
 	SessionId int
 	Name      string
 }
@@ -5929,6 +7183,11 @@ func (s PriestRequestClientPacket) Family() net.PacketFamily {
 
 func (s PriestRequestClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PriestRequestClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PriestRequestClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5953,6 +7212,7 @@ func (s *PriestRequestClientPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
@@ -5965,12 +7225,15 @@ func (s *PriestRequestClientPacket) Deserialize(reader *data.EoReader) (err erro
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PriestUseClientPacket :: Saying "I do" at a wedding.
 type PriestUseClientPacket struct {
+	byteSize int
+
 	SessionId int
 }
 
@@ -5980,6 +7243,11 @@ func (s PriestUseClientPacket) Family() net.PacketFamily {
 
 func (s PriestUseClientPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PriestUseClientPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PriestUseClientPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5997,8 +7265,10 @@ func (s *PriestUseClientPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }

--- a/pkg/eolib/protocol/net/client/structs_generated.go
+++ b/pkg/eolib/protocol/net/client/structs_generated.go
@@ -7,8 +7,15 @@ import (
 
 // ByteCoords :: Map coordinates with raw 1-byte values.
 type ByteCoords struct {
+	byteSize int
+
 	X int
 	Y int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ByteCoords) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ByteCoords) Serialize(writer *data.EoWriter) (err error) {
@@ -30,19 +37,28 @@ func (s *ByteCoords) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// X : field : byte
 	s.X = int(reader.GetByte())
 	// Y : field : byte
 	s.Y = int(reader.GetByte())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WalkAction :: Common data between walk packets.
 type WalkAction struct {
+	byteSize int
+
 	Direction protocol.Direction
 	Timestamp int
 	Coords    protocol.Coords
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WalkAction) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WalkAction) Serialize(writer *data.EoWriter) (err error) {
@@ -68,6 +84,7 @@ func (s *WalkAction) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
 	// Timestamp : field : three
@@ -76,6 +93,7 @@ func (s *WalkAction) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }

--- a/pkg/eolib/protocol/net/server/packets_generated.go
+++ b/pkg/eolib/protocol/net/server/packets_generated.go
@@ -1547,13 +1547,16 @@ func (s *CharacterReplyReplyCodeDataOk) Deserialize(reader *data.EoReader) (err 
 	s.CharactersCount = reader.GetChar()
 	// 0 : field : char
 	reader.GetChar()
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// Characters : array : CharacterSelectionListEntry
 	for ndx := 0; ndx < s.CharactersCount; ndx++ {
 		s.Characters = append(s.Characters, CharacterSelectionListEntry{})
 		if err = s.Characters[ndx].Deserialize(reader); err != nil {
+			return
+		}
+		if err = reader.NextChunk(); err != nil {
 			return
 		}
 	}
@@ -1592,13 +1595,16 @@ func (s *CharacterReplyReplyCodeDataDeleted) Deserialize(reader *data.EoReader) 
 
 	// CharactersCount : length : char
 	s.CharactersCount = reader.GetChar()
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// Characters : array : CharacterSelectionListEntry
 	for ndx := 0; ndx < s.CharactersCount; ndx++ {
 		s.Characters = append(s.Characters, CharacterSelectionListEntry{})
 		if err = s.Characters[ndx].Deserialize(reader); err != nil {
+			return
+		}
+		if err = reader.NextChunk(); err != nil {
 			return
 		}
 	}
@@ -1916,13 +1922,16 @@ func (s *LoginReplyReplyCodeDataOk) Deserialize(reader *data.EoReader) (err erro
 	s.CharactersCount = reader.GetChar()
 	// 0 : field : char
 	reader.GetChar()
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// Characters : array : CharacterSelectionListEntry
 	for ndx := 0; ndx < s.CharactersCount; ndx++ {
 		s.Characters = append(s.Characters, CharacterSelectionListEntry{})
 		if err = s.Characters[ndx].Deserialize(reader); err != nil {
+			return
+		}
+		if err = reader.NextChunk(); err != nil {
 			return
 		}
 	}
@@ -2370,32 +2379,32 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Deserialize(reader *data.Eo
 		return
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// Title : field : string
 	if s.Title, err = reader.GetString(); err != nil {
 		return
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// GuildName : field : string
 	if s.GuildName, err = reader.GetString(); err != nil {
 		return
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// GuildRankName : field : string
 	if s.GuildRankName, err = reader.GetString(); err != nil {
 		return
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// ClassId : field : char
 	s.ClassId = reader.GetChar()
@@ -2428,8 +2437,8 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Deserialize(reader *data.Eo
 	}
 	// LoginMessageCode : field : LoginMessageCode
 	s.LoginMessageCode = LoginMessageCode(reader.GetChar())
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 
 	return
@@ -2487,8 +2496,8 @@ func (s *WelcomeReplyWelcomeCodeDataEnterGame) Deserialize(reader *data.EoReader
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// News : array : string
 	for ndx := 0; ndx < 9; ndx++ {
@@ -2497,6 +2506,9 @@ func (s *WelcomeReplyWelcomeCodeDataEnterGame) Deserialize(reader *data.EoReader
 			return
 		}
 
+		if err = reader.NextChunk(); err != nil {
+			return
+		}
 	}
 
 	// Weight : field : Weight
@@ -2504,26 +2516,26 @@ func (s *WelcomeReplyWelcomeCodeDataEnterGame) Deserialize(reader *data.EoReader
 		return
 	}
 	// Items : array : Item
-	for ndx := 0; reader.Remaining() > 0; ndx++ {
+	for ndx := 0; ndx < reader.Remaining()/6; ndx++ {
 		s.Items = append(s.Items, net.Item{})
 		if err = s.Items[ndx].Deserialize(reader); err != nil {
 			return
 		}
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// Spells : array : Spell
-	for ndx := 0; reader.Remaining() > 0; ndx++ {
+	for ndx := 0; ndx < reader.Remaining()/4; ndx++ {
 		s.Spells = append(s.Spells, net.Spell{})
 		if err = s.Spells[ndx].Deserialize(reader); err != nil {
 			return
 		}
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// Nearby : field : NearbyInfo
 	if err = s.Nearby.Deserialize(reader); err != nil {
@@ -2641,16 +2653,16 @@ func (s *AdminInteractReplyMessageTypeDataMessage) Deserialize(reader *data.EoRe
 		return
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 
 	return
@@ -2693,24 +2705,24 @@ func (s *AdminInteractReplyMessageTypeDataReport) Deserialize(reader *data.EoRea
 		return
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 	// ReporteeName : field : string
 	if s.ReporteeName, err = reader.GetString(); err != nil {
 		return
 	}
 
-	if breakByte := reader.GetByte(); breakByte != 255 {
-		return fmt.Errorf("missing expected break byte")
+	if err = reader.NextChunk(); err != nil {
+		return
 	}
 
 	return
@@ -4690,7 +4702,7 @@ func (s *WalkReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// NpcIndexes : array : char
-	for ndx := 0; ndx < reader.Remaining()/1; ndx++ {
+	for ndx := 0; reader.Remaining() > 0; ndx++ {
 		s.NpcIndexes = append(s.NpcIndexes, 0)
 		s.NpcIndexes[ndx] = reader.GetChar()
 	}
@@ -5650,7 +5662,7 @@ func (s *ShopOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// CraftItems : array : ShopCraftItem
-	for ndx := 0; ndx < reader.Remaining()/2; ndx++ {
+	for ndx := 0; ndx < reader.Remaining()/14; ndx++ {
 		s.CraftItems = append(s.CraftItems, ShopCraftItem{})
 		if err = s.CraftItems[ndx].Deserialize(reader); err != nil {
 			return
@@ -5721,7 +5733,7 @@ func (s *StatSkillOpenServerPacket) Deserialize(reader *data.EoReader) (err erro
 		return
 	}
 	// Skills : array : SkillLearn
-	for ndx := 0; ndx < reader.Remaining()/20; ndx++ {
+	for ndx := 0; ndx < reader.Remaining()/28; ndx++ {
 		s.Skills = append(s.Skills, SkillLearn{})
 		if err = s.Skills[ndx].Deserialize(reader); err != nil {
 			return
@@ -11098,6 +11110,9 @@ func (s *QuestListPageDataProgress) Deserialize(reader *data.EoReader) (err erro
 		if err = s.QuestProgressEntries[ndx].Deserialize(reader); err != nil {
 			return
 		}
+		if err = reader.NextChunk(); err != nil {
+			return
+		}
 	}
 
 	return
@@ -11133,6 +11148,9 @@ func (s *QuestListPageDataHistory) Deserialize(reader *data.EoReader) (err error
 			return
 		}
 
+		if err = reader.NextChunk(); err != nil {
+			return
+		}
 	}
 
 	return

--- a/pkg/eolib/protocol/net/server/packets_generated.go
+++ b/pkg/eolib/protocol/net/server/packets_generated.go
@@ -10,6 +10,8 @@ import (
 
 // InitInitServerPacket ::  Reply to connection initialization and requests for unencrypted data. This packet is unencrypted.
 type InitInitServerPacket struct {
+	byteSize int
+
 	ReplyCode     InitReply
 	ReplyCodeData InitInitReplyCodeData
 }
@@ -19,7 +21,14 @@ type InitInitReplyCodeData interface {
 }
 
 type InitInitReplyCodeDataOutOfDate struct {
+	byteSize int
+
 	Version net.Version
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataOutOfDate) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataOutOfDate) Serialize(writer *data.EoWriter) (err error) {
@@ -37,21 +46,30 @@ func (s *InitInitReplyCodeDataOutOfDate) Deserialize(reader *data.EoReader) (err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Version : field : Version
 	if err = s.Version.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataOk struct {
+	byteSize int
+
 	Seq1                     int
 	Seq2                     int
 	ServerEncryptionMultiple int
 	ClientEncryptionMultiple int
 	PlayerId                 int
 	ChallengeResponse        int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataOk) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataOk) Serialize(writer *data.EoWriter) (err error) {
@@ -89,6 +107,7 @@ func (s *InitInitReplyCodeDataOk) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Seq1 : field : byte
 	s.Seq1 = int(reader.GetByte())
 	// Seq2 : field : byte
@@ -101,11 +120,14 @@ func (s *InitInitReplyCodeDataOk) Deserialize(reader *data.EoReader) (err error)
 	s.PlayerId = reader.GetShort()
 	// ChallengeResponse : field : three
 	s.ChallengeResponse = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataBanned struct {
+	byteSize int
+
 	BanType     InitBanType
 	BanTypeData InitInitBanTypeData
 }
@@ -116,7 +138,14 @@ type InitInitBanTypeData interface {
 
 // InitInitBanTypeData0 ::  The official client treats any value below 2 as a temporary ban. The official server sends 1, but some game server implementations. erroneously send 0.
 type InitInitBanTypeData0 struct {
+	byteSize int
+
 	MinutesRemaining int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitBanTypeData0) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitBanTypeData0) Serialize(writer *data.EoWriter) (err error) {
@@ -134,14 +163,23 @@ func (s *InitInitBanTypeData0) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MinutesRemaining : field : byte
 	s.MinutesRemaining = int(reader.GetByte())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitBanTypeDataTemporary struct {
+	byteSize int
+
 	MinutesRemaining int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitBanTypeDataTemporary) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitBanTypeDataTemporary) Serialize(writer *data.EoWriter) (err error) {
@@ -159,10 +197,17 @@ func (s *InitInitBanTypeDataTemporary) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MinutesRemaining : field : byte
 	s.MinutesRemaining = int(reader.GetByte())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataBanned) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataBanned) Serialize(writer *data.EoWriter) (err error) {
@@ -202,6 +247,7 @@ func (s *InitInitReplyCodeDataBanned) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// BanType : field : InitBanType
 	s.BanType = InitBanType(reader.GetByte())
 	switch s.BanType {
@@ -216,12 +262,20 @@ func (s *InitInitReplyCodeDataBanned) Deserialize(reader *data.EoReader) (err er
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataWarpMap struct {
+	byteSize int
+
 	MapFile MapFile
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataWarpMap) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataWarpMap) Serialize(writer *data.EoWriter) (err error) {
@@ -239,16 +293,25 @@ func (s *InitInitReplyCodeDataWarpMap) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapFile : field : MapFile
 	if err = s.MapFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataFileEmf struct {
+	byteSize int
+
 	MapFile MapFile
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataFileEmf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataFileEmf) Serialize(writer *data.EoWriter) (err error) {
@@ -266,16 +329,25 @@ func (s *InitInitReplyCodeDataFileEmf) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapFile : field : MapFile
 	if err = s.MapFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataFileEif struct {
+	byteSize int
+
 	PubFile PubFile
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataFileEif) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataFileEif) Serialize(writer *data.EoWriter) (err error) {
@@ -293,16 +365,25 @@ func (s *InitInitReplyCodeDataFileEif) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PubFile : field : PubFile
 	if err = s.PubFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataFileEnf struct {
+	byteSize int
+
 	PubFile PubFile
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataFileEnf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataFileEnf) Serialize(writer *data.EoWriter) (err error) {
@@ -320,16 +401,25 @@ func (s *InitInitReplyCodeDataFileEnf) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PubFile : field : PubFile
 	if err = s.PubFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataFileEsf struct {
+	byteSize int
+
 	PubFile PubFile
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataFileEsf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataFileEsf) Serialize(writer *data.EoWriter) (err error) {
@@ -347,16 +437,25 @@ func (s *InitInitReplyCodeDataFileEsf) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PubFile : field : PubFile
 	if err = s.PubFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataFileEcf struct {
+	byteSize int
+
 	PubFile PubFile
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataFileEcf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataFileEcf) Serialize(writer *data.EoWriter) (err error) {
@@ -374,16 +473,25 @@ func (s *InitInitReplyCodeDataFileEcf) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PubFile : field : PubFile
 	if err = s.PubFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataMapMutation struct {
+	byteSize int
+
 	MapFile MapFile
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataMapMutation) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataMapMutation) Serialize(writer *data.EoWriter) (err error) {
@@ -401,16 +509,25 @@ func (s *InitInitReplyCodeDataMapMutation) Deserialize(reader *data.EoReader) (e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapFile : field : MapFile
 	if err = s.MapFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataPlayersList struct {
+	byteSize int
+
 	PlayersList PlayersList
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataPlayersList) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataPlayersList) Serialize(writer *data.EoWriter) (err error) {
@@ -430,18 +547,27 @@ func (s *InitInitReplyCodeDataPlayersList) Deserialize(reader *data.EoReader) (e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayersList : field : PlayersList
 	if err = s.PlayersList.Deserialize(reader); err != nil {
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type InitInitReplyCodeDataPlayersListFriends struct {
+	byteSize int
+
 	PlayersList PlayersListFriends
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitReplyCodeDataPlayersListFriends) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitReplyCodeDataPlayersListFriends) Serialize(writer *data.EoWriter) (err error) {
@@ -461,12 +587,14 @@ func (s *InitInitReplyCodeDataPlayersListFriends) Deserialize(reader *data.EoRea
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayersList : field : PlayersListFriends
 	if err = s.PlayersList.Deserialize(reader); err != nil {
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -477,6 +605,11 @@ func (s InitInitServerPacket) Family() net.PacketFamily {
 
 func (s InitInitServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Init
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InitInitServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InitInitServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -616,6 +749,7 @@ func (s *InitInitServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ReplyCode : field : InitReply
 	s.ReplyCode = InitReply(reader.GetByte())
 	switch s.ReplyCode {
@@ -680,12 +814,15 @@ func (s *InitInitServerPacket) Deserialize(reader *data.EoReader) (err error) {
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WarpPlayerServerPacket :: Equivalent to INIT_INIT with InitReply.WarpMap.
 type WarpPlayerServerPacket struct {
+	byteSize int
+
 	MapFile MapFile
 }
 
@@ -695,6 +832,11 @@ func (s WarpPlayerServerPacket) Family() net.PacketFamily {
 
 func (s WarpPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WarpPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WarpPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -712,16 +854,20 @@ func (s *WarpPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapFile : field : MapFile
 	if err = s.MapFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WelcomePingServerPacket :: Equivalent to INIT_INIT with InitReply.FileMap.
 type WelcomePingServerPacket struct {
+	byteSize int
+
 	MapFile MapFile
 }
 
@@ -731,6 +877,11 @@ func (s WelcomePingServerPacket) Family() net.PacketFamily {
 
 func (s WelcomePingServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Ping
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomePingServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomePingServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -748,16 +899,20 @@ func (s *WelcomePingServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapFile : field : MapFile
 	if err = s.MapFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WelcomePongServerPacket :: Equivalent to INIT_INIT with InitReply.FileEif.
 type WelcomePongServerPacket struct {
+	byteSize int
+
 	PubFile PubFile
 }
 
@@ -767,6 +922,11 @@ func (s WelcomePongServerPacket) Family() net.PacketFamily {
 
 func (s WelcomePongServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Pong
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomePongServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomePongServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -784,16 +944,20 @@ func (s *WelcomePongServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PubFile : field : PubFile
 	if err = s.PubFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WelcomeNet242ServerPacket :: Equivalent to INIT_INIT with InitReply.FileEnf.
 type WelcomeNet242ServerPacket struct {
+	byteSize int
+
 	PubFile PubFile
 }
 
@@ -803,6 +967,11 @@ func (s WelcomeNet242ServerPacket) Family() net.PacketFamily {
 
 func (s WelcomeNet242ServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Net242
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeNet242ServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeNet242ServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -820,16 +989,20 @@ func (s *WelcomeNet242ServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PubFile : field : PubFile
 	if err = s.PubFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WelcomeNet243ServerPacket :: Equivalent to INIT_INIT with InitReply.FileEsf.
 type WelcomeNet243ServerPacket struct {
+	byteSize int
+
 	PubFile PubFile
 }
 
@@ -839,6 +1012,11 @@ func (s WelcomeNet243ServerPacket) Family() net.PacketFamily {
 
 func (s WelcomeNet243ServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Net243
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeNet243ServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeNet243ServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -856,16 +1034,20 @@ func (s *WelcomeNet243ServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PubFile : field : PubFile
 	if err = s.PubFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersListServerPacket :: Equivalent to INIT_INIT with InitReply.PlayersList.
 type PlayersListServerPacket struct {
+	byteSize int
+
 	PlayersList PlayersList
 }
 
@@ -875,6 +1057,11 @@ func (s PlayersListServerPacket) Family() net.PacketFamily {
 
 func (s PlayersListServerPacket) Action() net.PacketAction {
 	return net.PacketAction_List
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersListServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersListServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -894,18 +1081,22 @@ func (s *PlayersListServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayersList : field : PlayersList
 	if err = s.PlayersList.Deserialize(reader); err != nil {
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WarpCreateServerPacket :: Equivalent to INIT_INIT with InitReply.MapMutation.
 type WarpCreateServerPacket struct {
+	byteSize int
+
 	MapFile MapFile
 }
 
@@ -915,6 +1106,11 @@ func (s WarpCreateServerPacket) Family() net.PacketFamily {
 
 func (s WarpCreateServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Create
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WarpCreateServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WarpCreateServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -932,16 +1128,20 @@ func (s *WarpCreateServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapFile : field : MapFile
 	if err = s.MapFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersReplyServerPacket :: Equivalent to INIT_INIT with InitReply.PlayersListFriends.
 type PlayersReplyServerPacket struct {
+	byteSize int
+
 	PlayersList PlayersListFriends
 }
 
@@ -951,6 +1151,11 @@ func (s PlayersReplyServerPacket) Family() net.PacketFamily {
 
 func (s PlayersReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -970,18 +1175,22 @@ func (s *PlayersReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayersList : field : PlayersListFriends
 	if err = s.PlayersList.Deserialize(reader); err != nil {
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WelcomeNet244ServerPacket :: Equivalent to INIT_INIT with InitReply.FileEcf.
 type WelcomeNet244ServerPacket struct {
+	byteSize int
+
 	PubFile PubFile
 }
 
@@ -991,6 +1200,11 @@ func (s WelcomeNet244ServerPacket) Family() net.PacketFamily {
 
 func (s WelcomeNet244ServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Net244
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeNet244ServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeNet244ServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1008,16 +1222,20 @@ func (s *WelcomeNet244ServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PubFile : field : PubFile
 	if err = s.PubFile.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ConnectionPlayerServerPacket :: Ping request.
 type ConnectionPlayerServerPacket struct {
+	byteSize int
+
 	Seq1 int
 	Seq2 int
 }
@@ -1028,6 +1246,11 @@ func (s ConnectionPlayerServerPacket) Family() net.PacketFamily {
 
 func (s ConnectionPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ConnectionPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ConnectionPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1049,16 +1272,20 @@ func (s *ConnectionPlayerServerPacket) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Seq1 : field : short
 	s.Seq1 = reader.GetShort()
 	// Seq2 : field : char
 	s.Seq2 = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AccountReplyServerPacket :: Reply to client Account-family packets.
 type AccountReplyServerPacket struct {
+	byteSize int
+
 	ReplyCode     AccountReply //  Sometimes an AccountReply code, sometimes a session ID for account creation.
 	ReplyCodeData AccountReplyReplyCodeData
 }
@@ -1068,6 +1295,12 @@ type AccountReplyReplyCodeData interface {
 }
 
 type AccountReplyReplyCodeDataExists struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountReplyReplyCodeDataExists) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountReplyReplyCodeDataExists) Serialize(writer *data.EoWriter) (err error) {
@@ -1085,15 +1318,23 @@ func (s *AccountReplyReplyCodeDataExists) Deserialize(reader *data.EoReader) (er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type AccountReplyReplyCodeDataNotApproved struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountReplyReplyCodeDataNotApproved) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountReplyReplyCodeDataNotApproved) Serialize(writer *data.EoWriter) (err error) {
@@ -1111,15 +1352,23 @@ func (s *AccountReplyReplyCodeDataNotApproved) Deserialize(reader *data.EoReader
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type AccountReplyReplyCodeDataCreated struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountReplyReplyCodeDataCreated) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountReplyReplyCodeDataCreated) Serialize(writer *data.EoWriter) (err error) {
@@ -1137,15 +1386,23 @@ func (s *AccountReplyReplyCodeDataCreated) Deserialize(reader *data.EoReader) (e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type AccountReplyReplyCodeDataChangeFailed struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountReplyReplyCodeDataChangeFailed) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountReplyReplyCodeDataChangeFailed) Serialize(writer *data.EoWriter) (err error) {
@@ -1163,15 +1420,23 @@ func (s *AccountReplyReplyCodeDataChangeFailed) Deserialize(reader *data.EoReade
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type AccountReplyReplyCodeDataChanged struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountReplyReplyCodeDataChanged) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountReplyReplyCodeDataChanged) Serialize(writer *data.EoWriter) (err error) {
@@ -1189,15 +1454,23 @@ func (s *AccountReplyReplyCodeDataChanged) Deserialize(reader *data.EoReader) (e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type AccountReplyReplyCodeDataRequestDenied struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountReplyReplyCodeDataRequestDenied) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountReplyReplyCodeDataRequestDenied) Serialize(writer *data.EoWriter) (err error) {
@@ -1215,17 +1488,26 @@ func (s *AccountReplyReplyCodeDataRequestDenied) Deserialize(reader *data.EoRead
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AccountReplyReplyCodeDataDefault ::  In this case (reply_code > 9), reply_code is a session ID for account creation.
 type AccountReplyReplyCodeDataDefault struct {
+	byteSize int
+
 	SequenceStart int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountReplyReplyCodeDataDefault) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountReplyReplyCodeDataDefault) Serialize(writer *data.EoWriter) (err error) {
@@ -1247,12 +1529,14 @@ func (s *AccountReplyReplyCodeDataDefault) Deserialize(reader *data.EoReader) (e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SequenceStart : field : char
 	s.SequenceStart = reader.GetChar()
 	// OK : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -1263,6 +1547,11 @@ func (s AccountReplyServerPacket) Family() net.PacketFamily {
 
 func (s AccountReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AccountReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AccountReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1352,6 +1641,7 @@ func (s *AccountReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ReplyCode : field : AccountReply
 	s.ReplyCode = AccountReply(reader.GetShort())
 	switch s.ReplyCode {
@@ -1391,12 +1681,15 @@ func (s *AccountReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterReplyServerPacket :: Reply to client Character-family packets.
 type CharacterReplyServerPacket struct {
+	byteSize int
+
 	ReplyCode     CharacterReply //  Sometimes a CharacterReply code, sometimes a session ID for character creation.
 	ReplyCodeData CharacterReplyReplyCodeData
 }
@@ -1406,6 +1699,12 @@ type CharacterReplyReplyCodeData interface {
 }
 
 type CharacterReplyReplyCodeDataExists struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterReplyReplyCodeDataExists) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterReplyReplyCodeDataExists) Serialize(writer *data.EoWriter) (err error) {
@@ -1423,15 +1722,23 @@ func (s *CharacterReplyReplyCodeDataExists) Deserialize(reader *data.EoReader) (
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type CharacterReplyReplyCodeDataFull struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterReplyReplyCodeDataFull) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterReplyReplyCodeDataFull) Serialize(writer *data.EoWriter) (err error) {
@@ -1449,15 +1756,23 @@ func (s *CharacterReplyReplyCodeDataFull) Deserialize(reader *data.EoReader) (er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type CharacterReplyReplyCodeDataFull3 struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterReplyReplyCodeDataFull3) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterReplyReplyCodeDataFull3) Serialize(writer *data.EoWriter) (err error) {
@@ -1475,15 +1790,23 @@ func (s *CharacterReplyReplyCodeDataFull3) Deserialize(reader *data.EoReader) (e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type CharacterReplyReplyCodeDataNotApproved struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterReplyReplyCodeDataNotApproved) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterReplyReplyCodeDataNotApproved) Serialize(writer *data.EoWriter) (err error) {
@@ -1501,18 +1824,27 @@ func (s *CharacterReplyReplyCodeDataNotApproved) Deserialize(reader *data.EoRead
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type CharacterReplyReplyCodeDataOk struct {
+	byteSize int
+
 	CharactersCount int
 
 	Characters []CharacterSelectionListEntry
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterReplyReplyCodeDataOk) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterReplyReplyCodeDataOk) Serialize(writer *data.EoWriter) (err error) {
@@ -1543,6 +1875,7 @@ func (s *CharacterReplyReplyCodeDataOk) Deserialize(reader *data.EoReader) (err 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CharactersCount : length : char
 	s.CharactersCount = reader.GetChar()
 	// 0 : field : char
@@ -1561,12 +1894,21 @@ func (s *CharacterReplyReplyCodeDataOk) Deserialize(reader *data.EoReader) (err 
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 type CharacterReplyReplyCodeDataDeleted struct {
+	byteSize int
+
 	CharactersCount int
 	Characters      []CharacterSelectionListEntry
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterReplyReplyCodeDataDeleted) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterReplyReplyCodeDataDeleted) Serialize(writer *data.EoWriter) (err error) {
@@ -1593,6 +1935,7 @@ func (s *CharacterReplyReplyCodeDataDeleted) Deserialize(reader *data.EoReader) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CharactersCount : length : char
 	s.CharactersCount = reader.GetChar()
 	if err = reader.NextChunk(); err != nil {
@@ -1609,11 +1952,19 @@ func (s *CharacterReplyReplyCodeDataDeleted) Deserialize(reader *data.EoReader) 
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // CharacterReplyReplyCodeDataDefault ::  In this case (reply_code > 9), reply_code is a session ID for character creation.
 type CharacterReplyReplyCodeDataDefault struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterReplyReplyCodeDataDefault) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterReplyReplyCodeDataDefault) Serialize(writer *data.EoWriter) (err error) {
@@ -1631,10 +1982,12 @@ func (s *CharacterReplyReplyCodeDataDefault) Deserialize(reader *data.EoReader) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// OK : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -1645,6 +1998,11 @@ func (s CharacterReplyServerPacket) Family() net.PacketFamily {
 
 func (s CharacterReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1736,6 +2094,7 @@ func (s *CharacterReplyServerPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// ReplyCode : field : CharacterReply
 	s.ReplyCode = CharacterReply(reader.GetShort())
@@ -1777,12 +2136,15 @@ func (s *CharacterReplyServerPacket) Deserialize(reader *data.EoReader) (err err
 		}
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterPlayerServerPacket :: Reply to client request to delete a character from the account (Character_Take).
 type CharacterPlayerServerPacket struct {
+	byteSize int
+
 	SessionId   int
 	CharacterId int
 }
@@ -1793,6 +2155,11 @@ func (s CharacterPlayerServerPacket) Family() net.PacketFamily {
 
 func (s CharacterPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -1814,16 +2181,20 @@ func (s *CharacterPlayerServerPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
 	// CharacterId : field : int
 	s.CharacterId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // LoginReplyServerPacket :: Login reply.
 type LoginReplyServerPacket struct {
+	byteSize int
+
 	ReplyCode     LoginReply
 	ReplyCodeData LoginReplyReplyCodeData
 }
@@ -1833,6 +2204,12 @@ type LoginReplyReplyCodeData interface {
 }
 
 type LoginReplyReplyCodeDataWrongUser struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LoginReplyReplyCodeDataWrongUser) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LoginReplyReplyCodeDataWrongUser) Serialize(writer *data.EoWriter) (err error) {
@@ -1850,15 +2227,23 @@ func (s *LoginReplyReplyCodeDataWrongUser) Deserialize(reader *data.EoReader) (e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type LoginReplyReplyCodeDataWrongUserPassword struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LoginReplyReplyCodeDataWrongUserPassword) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LoginReplyReplyCodeDataWrongUserPassword) Serialize(writer *data.EoWriter) (err error) {
@@ -1876,18 +2261,27 @@ func (s *LoginReplyReplyCodeDataWrongUserPassword) Deserialize(reader *data.EoRe
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type LoginReplyReplyCodeDataOk struct {
+	byteSize int
+
 	CharactersCount int
 
 	Characters []CharacterSelectionListEntry
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LoginReplyReplyCodeDataOk) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LoginReplyReplyCodeDataOk) Serialize(writer *data.EoWriter) (err error) {
@@ -1918,6 +2312,7 @@ func (s *LoginReplyReplyCodeDataOk) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CharactersCount : length : char
 	s.CharactersCount = reader.GetChar()
 	// 0 : field : char
@@ -1936,10 +2331,18 @@ func (s *LoginReplyReplyCodeDataOk) Deserialize(reader *data.EoReader) (err erro
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 type LoginReplyReplyCodeDataBanned struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LoginReplyReplyCodeDataBanned) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LoginReplyReplyCodeDataBanned) Serialize(writer *data.EoWriter) (err error) {
@@ -1957,15 +2360,23 @@ func (s *LoginReplyReplyCodeDataBanned) Deserialize(reader *data.EoReader) (err 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type LoginReplyReplyCodeDataLoggedIn struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LoginReplyReplyCodeDataLoggedIn) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LoginReplyReplyCodeDataLoggedIn) Serialize(writer *data.EoWriter) (err error) {
@@ -1983,15 +2394,23 @@ func (s *LoginReplyReplyCodeDataLoggedIn) Deserialize(reader *data.EoReader) (er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type LoginReplyReplyCodeDataBusy struct {
+	byteSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LoginReplyReplyCodeDataBusy) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LoginReplyReplyCodeDataBusy) Serialize(writer *data.EoWriter) (err error) {
@@ -2009,10 +2428,12 @@ func (s *LoginReplyReplyCodeDataBusy) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NO : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -2023,6 +2444,11 @@ func (s LoginReplyServerPacket) Family() net.PacketFamily {
 
 func (s LoginReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LoginReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LoginReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2104,6 +2530,7 @@ func (s *LoginReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// ReplyCode : field : LoginReply
 	s.ReplyCode = LoginReply(reader.GetShort())
@@ -2140,12 +2567,15 @@ func (s *LoginReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 		}
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WelcomeReplyServerPacket :: Reply to selecting a character / entering game.
 type WelcomeReplyServerPacket struct {
+	byteSize int
+
 	WelcomeCode     WelcomeCode
 	WelcomeCodeData WelcomeReplyWelcomeCodeData
 }
@@ -2155,6 +2585,8 @@ type WelcomeReplyWelcomeCodeData interface {
 }
 
 type WelcomeReplyWelcomeCodeDataSelectCharacter struct {
+	byteSize int
+
 	SessionId        int
 	CharacterId      int
 	MapId            int
@@ -2183,6 +2615,11 @@ type WelcomeReplyWelcomeCodeDataSelectCharacter struct {
 	GuildRank        int
 	Settings         ServerSettings
 	LoginMessageCode LoginMessageCode
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Serialize(writer *data.EoWriter) (err error) {
@@ -2328,6 +2765,7 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Deserialize(reader *data.Eo
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
 	// CharacterId : field : int
@@ -2440,16 +2878,24 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Deserialize(reader *data.Eo
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type WelcomeReplyWelcomeCodeDataEnterGame struct {
+	byteSize int
+
 	News   []string
 	Weight net.Weight
 	Items  []net.Item
 	Spells []net.Spell
 	Nearby NearbyInfo
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeReplyWelcomeCodeDataEnterGame) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeReplyWelcomeCodeDataEnterGame) Serialize(writer *data.EoWriter) (err error) {
@@ -2496,6 +2942,7 @@ func (s *WelcomeReplyWelcomeCodeDataEnterGame) Deserialize(reader *data.EoReader
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
@@ -2543,6 +2990,7 @@ func (s *WelcomeReplyWelcomeCodeDataEnterGame) Deserialize(reader *data.EoReader
 	if err = s.Nearby.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -2553,6 +3001,11 @@ func (s WelcomeReplyServerPacket) Family() net.PacketFamily {
 
 func (s WelcomeReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WelcomeReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WelcomeReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2594,6 +3047,7 @@ func (s *WelcomeReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// WelcomeCode : field : WelcomeCode
 	s.WelcomeCode = WelcomeCode(reader.GetShort())
 	reader.SetIsChunked(true)
@@ -2610,12 +3064,15 @@ func (s *WelcomeReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 		}
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AdminInteractReplyServerPacket :: Incoming admin message.
 type AdminInteractReplyServerPacket struct {
+	byteSize int
+
 	MessageType     AdminMessageType
 	MessageTypeData AdminInteractReplyMessageTypeData
 }
@@ -2625,8 +3082,15 @@ type AdminInteractReplyMessageTypeData interface {
 }
 
 type AdminInteractReplyMessageTypeDataMessage struct {
+	byteSize int
+
 	PlayerName string
 	Message    string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AdminInteractReplyMessageTypeDataMessage) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AdminInteractReplyMessageTypeDataMessage) Serialize(writer *data.EoWriter) (err error) {
@@ -2650,6 +3114,7 @@ func (s *AdminInteractReplyMessageTypeDataMessage) Deserialize(reader *data.EoRe
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerName : field : string
 	if s.PlayerName, err = reader.GetString(); err != nil {
 		return
@@ -2666,14 +3131,22 @@ func (s *AdminInteractReplyMessageTypeDataMessage) Deserialize(reader *data.EoRe
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type AdminInteractReplyMessageTypeDataReport struct {
+	byteSize int
+
 	PlayerName   string
 	Message      string
 	ReporteeName string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AdminInteractReplyMessageTypeDataReport) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AdminInteractReplyMessageTypeDataReport) Serialize(writer *data.EoWriter) (err error) {
@@ -2702,6 +3175,7 @@ func (s *AdminInteractReplyMessageTypeDataReport) Deserialize(reader *data.EoRea
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerName : field : string
 	if s.PlayerName, err = reader.GetString(); err != nil {
 		return
@@ -2726,6 +3200,7 @@ func (s *AdminInteractReplyMessageTypeDataReport) Deserialize(reader *data.EoRea
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -2736,6 +3211,11 @@ func (s AdminInteractReplyServerPacket) Family() net.PacketFamily {
 
 func (s AdminInteractReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AdminInteractReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AdminInteractReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2778,6 +3258,7 @@ func (s *AdminInteractReplyServerPacket) Deserialize(reader *data.EoReader) (err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// MessageType : field : AdminMessageType
 	s.MessageType = AdminMessageType(reader.GetChar())
@@ -2797,12 +3278,15 @@ func (s *AdminInteractReplyServerPacket) Deserialize(reader *data.EoReader) (err
 		}
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AdminInteractRemoveServerPacket :: Nearby player disappearing (admin hide).
 type AdminInteractRemoveServerPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -2812,6 +3296,11 @@ func (s AdminInteractRemoveServerPacket) Family() net.PacketFamily {
 
 func (s AdminInteractRemoveServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AdminInteractRemoveServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AdminInteractRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2829,14 +3318,18 @@ func (s *AdminInteractRemoveServerPacket) Deserialize(reader *data.EoReader) (er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AdminInteractAgreeServerPacket :: Nearby player appearing (admin un-hide).
 type AdminInteractAgreeServerPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -2846,6 +3339,11 @@ func (s AdminInteractAgreeServerPacket) Family() net.PacketFamily {
 
 func (s AdminInteractAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AdminInteractAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AdminInteractAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2863,14 +3361,18 @@ func (s *AdminInteractAgreeServerPacket) Deserialize(reader *data.EoReader) (err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AdminInteractListServerPacket :: Admin character inventory popup.
 type AdminInteractListServerPacket struct {
+	byteSize int
+
 	Name      string
 	Usage     int
 	GoldBank  int
@@ -2884,6 +3386,11 @@ func (s AdminInteractListServerPacket) Family() net.PacketFamily {
 
 func (s AdminInteractListServerPacket) Action() net.PacketAction {
 	return net.PacketAction_List
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AdminInteractListServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AdminInteractListServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -2929,6 +3436,7 @@ func (s *AdminInteractListServerPacket) Deserialize(reader *data.EoReader) (err 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
@@ -2970,12 +3478,15 @@ func (s *AdminInteractListServerPacket) Deserialize(reader *data.EoReader) (err 
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AdminInteractTellServerPacket :: Admin character info lookup.
 type AdminInteractTellServerPacket struct {
+	byteSize int
+
 	Name      string
 	Usage     int
 	Exp       int
@@ -2992,6 +3503,11 @@ func (s AdminInteractTellServerPacket) Family() net.PacketFamily {
 
 func (s AdminInteractTellServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Tell
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AdminInteractTellServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AdminInteractTellServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3042,6 +3558,7 @@ func (s *AdminInteractTellServerPacket) Deserialize(reader *data.EoReader) (err 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
@@ -3078,12 +3595,15 @@ func (s *AdminInteractTellServerPacket) Deserialize(reader *data.EoReader) (err 
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkRequestServerPacket :: Guild chat message.
 type TalkRequestServerPacket struct {
+	byteSize int
+
 	PlayerName string
 	Message    string
 }
@@ -3094,6 +3614,11 @@ func (s TalkRequestServerPacket) Family() net.PacketFamily {
 
 func (s TalkRequestServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkRequestServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3118,6 +3643,7 @@ func (s *TalkRequestServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayerName : field : string
 	if s.PlayerName, err = reader.GetString(); err != nil {
@@ -3133,12 +3659,15 @@ func (s *TalkRequestServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkOpenServerPacket :: Party chat message.
 type TalkOpenServerPacket struct {
+	byteSize int
+
 	PlayerId int
 	Message  string
 }
@@ -3149,6 +3678,11 @@ func (s TalkOpenServerPacket) Family() net.PacketFamily {
 
 func (s TalkOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3170,6 +3704,7 @@ func (s *TalkOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Message : field : string
@@ -3177,11 +3712,15 @@ func (s *TalkOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // TalkMsgServerPacket :: Global chat message.
 type TalkMsgServerPacket struct {
+	byteSize int
+
 	PlayerName string
 	Message    string
 }
@@ -3192,6 +3731,11 @@ func (s TalkMsgServerPacket) Family() net.PacketFamily {
 
 func (s TalkMsgServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Msg
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkMsgServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkMsgServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3216,6 +3760,7 @@ func (s *TalkMsgServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayerName : field : string
 	if s.PlayerName, err = reader.GetString(); err != nil {
@@ -3231,12 +3776,15 @@ func (s *TalkMsgServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkTellServerPacket :: Private chat message.
 type TalkTellServerPacket struct {
+	byteSize int
+
 	PlayerName string
 	Message    string
 }
@@ -3247,6 +3795,11 @@ func (s TalkTellServerPacket) Family() net.PacketFamily {
 
 func (s TalkTellServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Tell
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkTellServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkTellServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3271,6 +3824,7 @@ func (s *TalkTellServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayerName : field : string
 	if s.PlayerName, err = reader.GetString(); err != nil {
@@ -3286,12 +3840,15 @@ func (s *TalkTellServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkPlayerServerPacket :: Public chat message.
 type TalkPlayerServerPacket struct {
+	byteSize int
+
 	PlayerId int
 	Message  string
 }
@@ -3302,6 +3859,11 @@ func (s TalkPlayerServerPacket) Family() net.PacketFamily {
 
 func (s TalkPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3323,6 +3885,7 @@ func (s *TalkPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Message : field : string
@@ -3330,11 +3893,15 @@ func (s *TalkPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) 
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // TalkReplyServerPacket :: Reply to trying to send a private message.
 type TalkReplyServerPacket struct {
+	byteSize int
+
 	ReplyCode TalkReply
 	Name      string
 }
@@ -3345,6 +3912,11 @@ func (s TalkReplyServerPacket) Family() net.PacketFamily {
 
 func (s TalkReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3366,6 +3938,7 @@ func (s *TalkReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ReplyCode : field : TalkReply
 	s.ReplyCode = TalkReply(reader.GetShort())
 	// Name : field : string
@@ -3373,11 +3946,15 @@ func (s *TalkReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // TalkAdminServerPacket :: Admin chat message.
 type TalkAdminServerPacket struct {
+	byteSize int
+
 	PlayerName string
 	Message    string
 }
@@ -3388,6 +3965,11 @@ func (s TalkAdminServerPacket) Family() net.PacketFamily {
 
 func (s TalkAdminServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Admin
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkAdminServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkAdminServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3412,6 +3994,7 @@ func (s *TalkAdminServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayerName : field : string
 	if s.PlayerName, err = reader.GetString(); err != nil {
@@ -3427,12 +4010,15 @@ func (s *TalkAdminServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkAnnounceServerPacket :: Admin announcement.
 type TalkAnnounceServerPacket struct {
+	byteSize int
+
 	PlayerName string
 	Message    string
 }
@@ -3443,6 +4029,11 @@ func (s TalkAnnounceServerPacket) Family() net.PacketFamily {
 
 func (s TalkAnnounceServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Announce
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkAnnounceServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkAnnounceServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3467,6 +4058,7 @@ func (s *TalkAnnounceServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayerName : field : string
 	if s.PlayerName, err = reader.GetString(); err != nil {
@@ -3482,12 +4074,15 @@ func (s *TalkAnnounceServerPacket) Deserialize(reader *data.EoReader) (err error
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkServerServerPacket :: Server message.
 type TalkServerServerPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -3497,6 +4092,11 @@ func (s TalkServerServerPacket) Family() net.PacketFamily {
 
 func (s TalkServerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Server
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkServerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkServerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3514,16 +4114,21 @@ func (s *TalkServerServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkListServerPacket ::  Global chat backfill. Sent by the official game server when a player opens the global chat tab.
 type TalkListServerPacket struct {
+	byteSize int
+
 	Messages []GlobalBackfillMessage
 }
 
@@ -3533,6 +4138,11 @@ func (s TalkListServerPacket) Family() net.PacketFamily {
 
 func (s TalkListServerPacket) Action() net.PacketAction {
 	return net.PacketAction_List
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkListServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkListServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3556,6 +4166,7 @@ func (s *TalkListServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Messages : array : GlobalBackfillMessage
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
@@ -3569,12 +4180,15 @@ func (s *TalkListServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MessageOpenServerPacket :: Status bar message.
 type MessageOpenServerPacket struct {
+	byteSize int
+
 	Message string
 }
 
@@ -3584,6 +4198,11 @@ func (s MessageOpenServerPacket) Family() net.PacketFamily {
 
 func (s MessageOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MessageOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MessageOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3601,16 +4220,20 @@ func (s *MessageOpenServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Message : field : string
 	if s.Message, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MessageCloseServerPacket :: Server is rebooting.
 type MessageCloseServerPacket struct {
+	byteSize int
 }
 
 func (s MessageCloseServerPacket) Family() net.PacketFamily {
@@ -3619,6 +4242,11 @@ func (s MessageCloseServerPacket) Family() net.PacketFamily {
 
 func (s MessageCloseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Close
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MessageCloseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MessageCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3636,16 +4264,20 @@ func (s *MessageCloseServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// r : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MessageAcceptServerPacket :: Large message box.
 type MessageAcceptServerPacket struct {
+	byteSize int
+
 	Messages []string
 }
 
@@ -3655,6 +4287,11 @@ func (s MessageAcceptServerPacket) Family() net.PacketFamily {
 
 func (s MessageAcceptServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MessageAcceptServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MessageAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3678,6 +4315,7 @@ func (s *MessageAcceptServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Messages : array : string
 	for ndx := 0; ndx < 4; ndx++ {
@@ -3692,12 +4330,15 @@ func (s *MessageAcceptServerPacket) Deserialize(reader *data.EoReader) (err erro
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TalkSpecServerPacket :: Temporary mute applied.
 type TalkSpecServerPacket struct {
+	byteSize int
+
 	AdminName string
 }
 
@@ -3707,6 +4348,11 @@ func (s TalkSpecServerPacket) Family() net.PacketFamily {
 
 func (s TalkSpecServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Spec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkSpecServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3724,16 +4370,21 @@ func (s *TalkSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// AdminName : field : string
 	if s.AdminName, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AttackPlayerServerPacket :: Nearby player attacking.
 type AttackPlayerServerPacket struct {
+	byteSize int
+
 	PlayerId  int
 	Direction protocol.Direction
 }
@@ -3744,6 +4395,11 @@ func (s AttackPlayerServerPacket) Family() net.PacketFamily {
 
 func (s AttackPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AttackPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AttackPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3765,16 +4421,19 @@ func (s *AttackPlayerServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AttackErrorServerPacket :: Show flood protection message (vestigial).
 type AttackErrorServerPacket struct {
+	byteSize int
 }
 
 func (s AttackErrorServerPacket) Family() net.PacketFamily {
@@ -3783,6 +4442,11 @@ func (s AttackErrorServerPacket) Family() net.PacketFamily {
 
 func (s AttackErrorServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Error
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AttackErrorServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AttackErrorServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3800,14 +4464,18 @@ func (s *AttackErrorServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 255 : dummy : byte
 	reader.GetByte()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AvatarReplyServerPacket :: Nearby player hit by another player.
 type AvatarReplyServerPacket struct {
+	byteSize int
+
 	PlayerId     int
 	VictimId     int
 	Damage       int
@@ -3822,6 +4490,11 @@ func (s AvatarReplyServerPacket) Family() net.PacketFamily {
 
 func (s AvatarReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AvatarReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AvatarReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3865,6 +4538,7 @@ func (s *AvatarReplyServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// VictimId : field : short
@@ -3881,12 +4555,15 @@ func (s *AvatarReplyServerPacket) Deserialize(reader *data.EoReader) (err error)
 	} else {
 		s.Dead = false
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ChairPlayerServerPacket :: Nearby player sitting on a chair.
 type ChairPlayerServerPacket struct {
+	byteSize int
+
 	PlayerId  int
 	Coords    protocol.Coords
 	Direction protocol.Direction
@@ -3898,6 +4575,11 @@ func (s ChairPlayerServerPacket) Family() net.PacketFamily {
 
 func (s ChairPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChairPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChairPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3923,6 +4605,7 @@ func (s *ChairPlayerServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Coords : field : Coords
@@ -3931,12 +4614,15 @@ func (s *ChairPlayerServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ChairReplyServerPacket :: Your character sitting on a chair.
 type ChairReplyServerPacket struct {
+	byteSize int
+
 	PlayerId  int
 	Coords    protocol.Coords
 	Direction protocol.Direction
@@ -3948,6 +4634,11 @@ func (s ChairReplyServerPacket) Family() net.PacketFamily {
 
 func (s ChairReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChairReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChairReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -3973,6 +4664,7 @@ func (s *ChairReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Coords : field : Coords
@@ -3981,12 +4673,15 @@ func (s *ChairReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	}
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ChairCloseServerPacket :: Your character standing up from a chair.
 type ChairCloseServerPacket struct {
+	byteSize int
+
 	PlayerId int
 	Coords   protocol.Coords
 }
@@ -3997,6 +4692,11 @@ func (s ChairCloseServerPacket) Family() net.PacketFamily {
 
 func (s ChairCloseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Close
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChairCloseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChairCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4018,18 +4718,22 @@ func (s *ChairCloseServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ChairRemoveServerPacket :: Nearby player standing up from a chair.
 type ChairRemoveServerPacket struct {
+	byteSize int
+
 	PlayerId int
 	Coords   protocol.Coords
 }
@@ -4040,6 +4744,11 @@ func (s ChairRemoveServerPacket) Family() net.PacketFamily {
 
 func (s ChairRemoveServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChairRemoveServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChairRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4061,18 +4770,22 @@ func (s *ChairRemoveServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SitPlayerServerPacket :: Nearby player sitting down.
 type SitPlayerServerPacket struct {
+	byteSize int
+
 	PlayerId  int
 	Coords    protocol.Coords
 	Direction protocol.Direction
@@ -4084,6 +4797,11 @@ func (s SitPlayerServerPacket) Family() net.PacketFamily {
 
 func (s SitPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SitPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SitPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4113,6 +4831,7 @@ func (s *SitPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Coords : field : Coords
@@ -4123,12 +4842,15 @@ func (s *SitPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	s.Direction = protocol.Direction(reader.GetChar())
 	// 0 : field : char
 	reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SitCloseServerPacket :: Your character standing up.
 type SitCloseServerPacket struct {
+	byteSize int
+
 	PlayerId int
 	Coords   protocol.Coords
 }
@@ -4139,6 +4861,11 @@ func (s SitCloseServerPacket) Family() net.PacketFamily {
 
 func (s SitCloseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Close
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SitCloseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SitCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4160,18 +4887,22 @@ func (s *SitCloseServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SitRemoveServerPacket :: Nearby player standing up.
 type SitRemoveServerPacket struct {
+	byteSize int
+
 	PlayerId int
 	Coords   protocol.Coords
 }
@@ -4182,6 +4913,11 @@ func (s SitRemoveServerPacket) Family() net.PacketFamily {
 
 func (s SitRemoveServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SitRemoveServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SitRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4203,18 +4939,22 @@ func (s *SitRemoveServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SitReplyServerPacket :: Your character sitting down.
 type SitReplyServerPacket struct {
+	byteSize int
+
 	PlayerId  int
 	Coords    protocol.Coords
 	Direction protocol.Direction
@@ -4226,6 +4966,11 @@ func (s SitReplyServerPacket) Family() net.PacketFamily {
 
 func (s SitReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SitReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SitReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4255,6 +5000,7 @@ func (s *SitReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Coords : field : Coords
@@ -4265,12 +5011,15 @@ func (s *SitReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	s.Direction = protocol.Direction(reader.GetChar())
 	// 0 : field : char
 	reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EmotePlayerServerPacket :: Nearby player doing an emote.
 type EmotePlayerServerPacket struct {
+	byteSize int
+
 	PlayerId int
 	Emote    protocol.Emote
 }
@@ -4281,6 +5030,11 @@ func (s EmotePlayerServerPacket) Family() net.PacketFamily {
 
 func (s EmotePlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EmotePlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EmotePlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4302,16 +5056,20 @@ func (s *EmotePlayerServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Emote : field : Emote
 	s.Emote = protocol.Emote(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EffectPlayerServerPacket :: Effects playing on nearby players.
 type EffectPlayerServerPacket struct {
+	byteSize int
+
 	Effects []PlayerEffect
 }
 
@@ -4321,6 +5079,11 @@ func (s EffectPlayerServerPacket) Family() net.PacketFamily {
 
 func (s EffectPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EffectPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EffectPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4341,6 +5104,7 @@ func (s *EffectPlayerServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Effects : array : PlayerEffect
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
 		s.Effects = append(s.Effects, PlayerEffect{})
@@ -4349,11 +5113,15 @@ func (s *EffectPlayerServerPacket) Deserialize(reader *data.EoReader) (err error
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // FacePlayerServerPacket :: Nearby player facing a direction.
 type FacePlayerServerPacket struct {
+	byteSize int
+
 	PlayerId  int
 	Direction protocol.Direction
 }
@@ -4364,6 +5132,11 @@ func (s FacePlayerServerPacket) Family() net.PacketFamily {
 
 func (s FacePlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *FacePlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *FacePlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4385,16 +5158,20 @@ func (s *FacePlayerServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AvatarRemoveServerPacket :: Nearby player has disappeared from view.
 type AvatarRemoveServerPacket struct {
+	byteSize int
+
 	PlayerId   int
 	WarpEffect *WarpEffect
 }
@@ -4405,6 +5182,11 @@ func (s AvatarRemoveServerPacket) Family() net.PacketFamily {
 
 func (s AvatarRemoveServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AvatarRemoveServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AvatarRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4428,6 +5210,7 @@ func (s *AvatarRemoveServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// WarpEffect : field : WarpEffect
@@ -4435,12 +5218,15 @@ func (s *AvatarRemoveServerPacket) Deserialize(reader *data.EoReader) (err error
 		s.WarpEffect = new(WarpEffect)
 		*s.WarpEffect = WarpEffect(reader.GetChar())
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersAgreeServerPacket :: Player has appeared in nearby view.
 type PlayersAgreeServerPacket struct {
+	byteSize int
+
 	Nearby NearbyInfo
 }
 
@@ -4450,6 +5236,11 @@ func (s PlayersAgreeServerPacket) Family() net.PacketFamily {
 
 func (s PlayersAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4467,16 +5258,20 @@ func (s *PlayersAgreeServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Nearby : field : NearbyInfo
 	if err = s.Nearby.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersRemoveServerPacket :: Nearby player has logged out.
 type PlayersRemoveServerPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -4486,6 +5281,11 @@ func (s PlayersRemoveServerPacket) Family() net.PacketFamily {
 
 func (s PlayersRemoveServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersRemoveServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4503,14 +5303,18 @@ func (s *PlayersRemoveServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // RangeReplyServerPacket :: Reply to request for information about nearby players and NPCs.
 type RangeReplyServerPacket struct {
+	byteSize int
+
 	Nearby NearbyInfo
 }
 
@@ -4520,6 +5324,11 @@ func (s RangeReplyServerPacket) Family() net.PacketFamily {
 
 func (s RangeReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *RangeReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *RangeReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4537,16 +5346,20 @@ func (s *RangeReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Nearby : field : NearbyInfo
 	if err = s.Nearby.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcAgreeServerPacket :: Reply to request for information about nearby NPCs.
 type NpcAgreeServerPacket struct {
+	byteSize int
+
 	NpcsCount int
 	Npcs      []NpcMapInfo
 }
@@ -4557,6 +5370,11 @@ func (s NpcAgreeServerPacket) Family() net.PacketFamily {
 
 func (s NpcAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4581,6 +5399,7 @@ func (s *NpcAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcsCount : length : char
 	s.NpcsCount = reader.GetChar()
 	// Npcs : array : NpcMapInfo
@@ -4591,11 +5410,15 @@ func (s *NpcAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // WalkPlayerServerPacket :: Nearby player has walked.
 type WalkPlayerServerPacket struct {
+	byteSize int
+
 	PlayerId  int
 	Direction protocol.Direction
 	Coords    protocol.Coords
@@ -4607,6 +5430,11 @@ func (s WalkPlayerServerPacket) Family() net.PacketFamily {
 
 func (s WalkPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WalkPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WalkPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4632,6 +5460,7 @@ func (s *WalkPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Direction : field : Direction
@@ -4640,12 +5469,15 @@ func (s *WalkPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WalkReplyServerPacket :: Players, NPCs, and Items appearing in nearby view.
 type WalkReplyServerPacket struct {
+	byteSize int
+
 	PlayerIds  []int
 	NpcIndexes []int
 	Items      []ItemMapInfo
@@ -4657,6 +5489,11 @@ func (s WalkReplyServerPacket) Family() net.PacketFamily {
 
 func (s WalkReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WalkReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WalkReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4695,6 +5532,7 @@ func (s *WalkReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayerIds : array : short
 	PlayerIdsRemaining := reader.Remaining()
@@ -4725,12 +5563,14 @@ func (s *WalkReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WalkCloseServerPacket :: Your character has been frozen.
 type WalkCloseServerPacket struct {
+	byteSize int
 }
 
 func (s WalkCloseServerPacket) Family() net.PacketFamily {
@@ -4739,6 +5579,11 @@ func (s WalkCloseServerPacket) Family() net.PacketFamily {
 
 func (s WalkCloseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Close
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WalkCloseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WalkCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4756,16 +5601,19 @@ func (s *WalkCloseServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// S : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WalkOpenServerPacket :: Your character has been unfrozen.
 type WalkOpenServerPacket struct {
+	byteSize int
 }
 
 func (s WalkOpenServerPacket) Family() net.PacketFamily {
@@ -4774,6 +5622,11 @@ func (s WalkOpenServerPacket) Family() net.PacketFamily {
 
 func (s WalkOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WalkOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WalkOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4791,16 +5644,20 @@ func (s *WalkOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// S : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BankOpenServerPacket :: Open banker NPC interface.
 type BankOpenServerPacket struct {
+	byteSize int
+
 	GoldBank       int
 	SessionId      int
 	LockerUpgrades int
@@ -4812,6 +5669,11 @@ func (s BankOpenServerPacket) Family() net.PacketFamily {
 
 func (s BankOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BankOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BankOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4837,18 +5699,22 @@ func (s *BankOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GoldBank : field : int
 	s.GoldBank = reader.GetInt()
 	// SessionId : field : three
 	s.SessionId = reader.GetThree()
 	// LockerUpgrades : field : char
 	s.LockerUpgrades = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BankReplyServerPacket :: Update gold counts after deposit/withdraw.
 type BankReplyServerPacket struct {
+	byteSize int
+
 	GoldInventory int
 	GoldBank      int
 }
@@ -4859,6 +5725,11 @@ func (s BankReplyServerPacket) Family() net.PacketFamily {
 
 func (s BankReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BankReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BankReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4880,16 +5751,20 @@ func (s *BankReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GoldInventory : field : int
 	s.GoldInventory = reader.GetInt()
 	// GoldBank : field : int
 	s.GoldBank = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BarberAgreeServerPacket :: Purchasing a new hair style.
 type BarberAgreeServerPacket struct {
+	byteSize int
+
 	GoldAmount int
 	Change     AvatarChange
 }
@@ -4900,6 +5775,11 @@ func (s BarberAgreeServerPacket) Family() net.PacketFamily {
 
 func (s BarberAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BarberAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BarberAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4921,18 +5801,22 @@ func (s *BarberAgreeServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
 	// Change : field : AvatarChange
 	if err = s.Change.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BarberOpenServerPacket :: Response from talking to a barber NPC.
 type BarberOpenServerPacket struct {
+	byteSize int
+
 	SessionId int
 }
 
@@ -4942,6 +5826,11 @@ func (s BarberOpenServerPacket) Family() net.PacketFamily {
 
 func (s BarberOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BarberOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BarberOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -4959,14 +5848,18 @@ func (s *BarberOpenServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // LockerReplyServerPacket :: Response to adding an item to a bank locker.
 type LockerReplyServerPacket struct {
+	byteSize int
+
 	DepositedItem net.Item
 	Weight        net.Weight
 	LockerItems   []net.ThreeItem
@@ -4978,6 +5871,11 @@ func (s LockerReplyServerPacket) Family() net.PacketFamily {
 
 func (s LockerReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LockerReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LockerReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5006,6 +5904,7 @@ func (s *LockerReplyServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// DepositedItem : field : Item
 	if err = s.DepositedItem.Deserialize(reader); err != nil {
 		return
@@ -5022,11 +5921,15 @@ func (s *LockerReplyServerPacket) Deserialize(reader *data.EoReader) (err error)
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // LockerGetServerPacket :: Response to taking an item from a bank locker.
 type LockerGetServerPacket struct {
+	byteSize int
+
 	TakenItem   net.ThreeItem
 	Weight      net.Weight
 	LockerItems []net.ThreeItem
@@ -5038,6 +5941,11 @@ func (s LockerGetServerPacket) Family() net.PacketFamily {
 
 func (s LockerGetServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Get
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LockerGetServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LockerGetServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5066,6 +5974,7 @@ func (s *LockerGetServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// TakenItem : field : ThreeItem
 	if err = s.TakenItem.Deserialize(reader); err != nil {
 		return
@@ -5082,11 +5991,15 @@ func (s *LockerGetServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // LockerOpenServerPacket :: Opening a bank locker.
 type LockerOpenServerPacket struct {
+	byteSize int
+
 	LockerCoords protocol.Coords
 	LockerItems  []net.ThreeItem
 }
@@ -5097,6 +6010,11 @@ func (s LockerOpenServerPacket) Family() net.PacketFamily {
 
 func (s LockerOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LockerOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LockerOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5121,6 +6039,7 @@ func (s *LockerOpenServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// LockerCoords : field : Coords
 	if err = s.LockerCoords.Deserialize(reader); err != nil {
 		return
@@ -5133,11 +6052,15 @@ func (s *LockerOpenServerPacket) Deserialize(reader *data.EoReader) (err error) 
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // LockerBuyServerPacket :: Response to buying a locker space upgrade from a banker NPC.
 type LockerBuyServerPacket struct {
+	byteSize int
+
 	GoldAmount     int
 	LockerUpgrades int
 }
@@ -5148,6 +6071,11 @@ func (s LockerBuyServerPacket) Family() net.PacketFamily {
 
 func (s LockerBuyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Buy
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LockerBuyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LockerBuyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5169,16 +6097,20 @@ func (s *LockerBuyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
 	// LockerUpgrades : field : char
 	s.LockerUpgrades = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // LockerSpecServerPacket :: Reply to trying to add an item to a full locker.
 type LockerSpecServerPacket struct {
+	byteSize int
+
 	LockerMaxItems int
 }
 
@@ -5188,6 +6120,11 @@ func (s LockerSpecServerPacket) Family() net.PacketFamily {
 
 func (s LockerSpecServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Spec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LockerSpecServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LockerSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5205,14 +6142,18 @@ func (s *LockerSpecServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// LockerMaxItems : field : char
 	s.LockerMaxItems = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CitizenReplyServerPacket :: Response to subscribing to a town.
 type CitizenReplyServerPacket struct {
+	byteSize int
+
 	QuestionsWrong int
 }
 
@@ -5222,6 +6163,11 @@ func (s CitizenReplyServerPacket) Family() net.PacketFamily {
 
 func (s CitizenReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CitizenReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CitizenReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5239,14 +6185,18 @@ func (s *CitizenReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// QuestionsWrong : field : char
 	s.QuestionsWrong = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CitizenRemoveServerPacket :: Response to giving up citizenship of a town.
 type CitizenRemoveServerPacket struct {
+	byteSize int
+
 	ReplyCode InnUnsubscribeReply
 }
 
@@ -5256,6 +6206,11 @@ func (s CitizenRemoveServerPacket) Family() net.PacketFamily {
 
 func (s CitizenRemoveServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CitizenRemoveServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CitizenRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5273,14 +6228,18 @@ func (s *CitizenRemoveServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ReplyCode : field : InnUnsubscribeReply
 	s.ReplyCode = InnUnsubscribeReply(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CitizenOpenServerPacket :: Response from talking to a citizenship NPC.
 type CitizenOpenServerPacket struct {
+	byteSize int
+
 	BehaviorId    int
 	CurrentHomeId int
 	SessionId     int
@@ -5293,6 +6252,11 @@ func (s CitizenOpenServerPacket) Family() net.PacketFamily {
 
 func (s CitizenOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CitizenOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CitizenOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5332,6 +6296,7 @@ func (s *CitizenOpenServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// BehaviorId : field : three
 	s.BehaviorId = reader.GetThree()
@@ -5357,12 +6322,15 @@ func (s *CitizenOpenServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CitizenRequestServerPacket :: Reply to requesting sleeping at an inn.
 type CitizenRequestServerPacket struct {
+	byteSize int
+
 	Cost int
 }
 
@@ -5372,6 +6340,11 @@ func (s CitizenRequestServerPacket) Family() net.PacketFamily {
 
 func (s CitizenRequestServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CitizenRequestServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CitizenRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5389,14 +6362,18 @@ func (s *CitizenRequestServerPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Cost : field : int
 	s.Cost = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CitizenAcceptServerPacket :: Sleeping at an inn.
 type CitizenAcceptServerPacket struct {
+	byteSize int
+
 	GoldAmount int
 }
 
@@ -5406,6 +6383,11 @@ func (s CitizenAcceptServerPacket) Family() net.PacketFamily {
 
 func (s CitizenAcceptServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CitizenAcceptServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CitizenAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5423,14 +6405,18 @@ func (s *CitizenAcceptServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopCreateServerPacket :: Response to crafting an item from a shop.
 type ShopCreateServerPacket struct {
+	byteSize int
+
 	CraftItemId int
 	Weight      net.Weight
 	Ingredients []net.Item
@@ -5442,6 +6428,11 @@ func (s ShopCreateServerPacket) Family() net.PacketFamily {
 
 func (s ShopCreateServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Create
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopCreateServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopCreateServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5470,6 +6461,7 @@ func (s *ShopCreateServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CraftItemId : field : short
 	s.CraftItemId = reader.GetShort()
 	// Weight : field : Weight
@@ -5484,11 +6476,15 @@ func (s *ShopCreateServerPacket) Deserialize(reader *data.EoReader) (err error) 
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // ShopBuyServerPacket :: Response to purchasing an item from a shop.
 type ShopBuyServerPacket struct {
+	byteSize int
+
 	GoldAmount int
 	BoughtItem net.Item
 	Weight     net.Weight
@@ -5500,6 +6496,11 @@ func (s ShopBuyServerPacket) Family() net.PacketFamily {
 
 func (s ShopBuyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Buy
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopBuyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopBuyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5525,6 +6526,7 @@ func (s *ShopBuyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
 	// BoughtItem : field : Item
@@ -5535,12 +6537,15 @@ func (s *ShopBuyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Weight.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopSellServerPacket :: Response to selling an item to a shop.
 type ShopSellServerPacket struct {
+	byteSize int
+
 	SoldItem   ShopSoldItem
 	GoldAmount int
 	Weight     net.Weight
@@ -5552,6 +6557,11 @@ func (s ShopSellServerPacket) Family() net.PacketFamily {
 
 func (s ShopSellServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Sell
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopSellServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopSellServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5577,6 +6587,7 @@ func (s *ShopSellServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SoldItem : field : ShopSoldItem
 	if err = s.SoldItem.Deserialize(reader); err != nil {
 		return
@@ -5587,12 +6598,15 @@ func (s *ShopSellServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Weight.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopOpenServerPacket :: Response from talking to a shop NPC.
 type ShopOpenServerPacket struct {
+	byteSize int
+
 	SessionId  int
 	ShopName   string
 	TradeItems []ShopTradeItem
@@ -5605,6 +6619,11 @@ func (s ShopOpenServerPacket) Family() net.PacketFamily {
 
 func (s ShopOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5645,6 +6664,7 @@ func (s *ShopOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
@@ -5681,12 +6701,15 @@ func (s *ShopOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillOpenServerPacket :: Response from talking to a skill master NPC.
 type StatSkillOpenServerPacket struct {
+	byteSize int
+
 	SessionId int
 	ShopName  string
 	Skills    []SkillLearn
@@ -5698,6 +6721,11 @@ func (s StatSkillOpenServerPacket) Family() net.PacketFamily {
 
 func (s StatSkillOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5729,6 +6757,7 @@ func (s *StatSkillOpenServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
@@ -5750,12 +6779,15 @@ func (s *StatSkillOpenServerPacket) Deserialize(reader *data.EoReader) (err erro
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillReplyServerPacket :: Response from unsuccessful action at a skill master.
 type StatSkillReplyServerPacket struct {
+	byteSize int
+
 	ReplyCode     SkillMasterReply
 	ReplyCodeData StatSkillReplyReplyCodeData
 }
@@ -5765,7 +6797,14 @@ type StatSkillReplyReplyCodeData interface {
 }
 
 type StatSkillReplyReplyCodeDataWrongClass struct {
+	byteSize int
+
 	ClassId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillReplyReplyCodeDataWrongClass) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillReplyReplyCodeDataWrongClass) Serialize(writer *data.EoWriter) (err error) {
@@ -5783,8 +6822,10 @@ func (s *StatSkillReplyReplyCodeDataWrongClass) Deserialize(reader *data.EoReade
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ClassId : field : char
 	s.ClassId = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -5795,6 +6836,11 @@ func (s StatSkillReplyServerPacket) Family() net.PacketFamily {
 
 func (s StatSkillReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5824,6 +6870,7 @@ func (s *StatSkillReplyServerPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ReplyCode : field : SkillMasterReply
 	s.ReplyCode = SkillMasterReply(reader.GetShort())
 	switch s.ReplyCode {
@@ -5833,12 +6880,15 @@ func (s *StatSkillReplyServerPacket) Deserialize(reader *data.EoReader) (err err
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillTakeServerPacket :: Response from learning a skill from a skill master.
 type StatSkillTakeServerPacket struct {
+	byteSize int
+
 	SpellId    int
 	GoldAmount int
 }
@@ -5849,6 +6899,11 @@ func (s StatSkillTakeServerPacket) Family() net.PacketFamily {
 
 func (s StatSkillTakeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillTakeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillTakeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5870,16 +6925,20 @@ func (s *StatSkillTakeServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillRemoveServerPacket :: Response to forgetting a skill at a skill master.
 type StatSkillRemoveServerPacket struct {
+	byteSize int
+
 	SpellId int
 }
 
@@ -5889,6 +6948,11 @@ func (s StatSkillRemoveServerPacket) Family() net.PacketFamily {
 
 func (s StatSkillRemoveServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillRemoveServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5906,14 +6970,18 @@ func (s *StatSkillRemoveServerPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillPlayerServerPacket :: Response to spending stat points.
 type StatSkillPlayerServerPacket struct {
+	byteSize int
+
 	StatPoints int
 	Stats      CharacterStatsUpdate
 }
@@ -5924,6 +6992,11 @@ func (s StatSkillPlayerServerPacket) Family() net.PacketFamily {
 
 func (s StatSkillPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5945,18 +7018,22 @@ func (s *StatSkillPlayerServerPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// StatPoints : field : short
 	s.StatPoints = reader.GetShort()
 	// Stats : field : CharacterStatsUpdate
 	if err = s.Stats.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillAcceptServerPacket :: Response to spending skill points.
 type StatSkillAcceptServerPacket struct {
+	byteSize int
+
 	SkillPoints int
 	Spell       net.Spell
 }
@@ -5967,6 +7044,11 @@ func (s StatSkillAcceptServerPacket) Family() net.PacketFamily {
 
 func (s StatSkillAcceptServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillAcceptServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -5988,18 +7070,22 @@ func (s *StatSkillAcceptServerPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SkillPoints : field : short
 	s.SkillPoints = reader.GetShort()
 	// Spell : field : Spell
 	if err = s.Spell.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // StatSkillJunkServerPacket :: Response to resetting stats and skills at a skill master.
 type StatSkillJunkServerPacket struct {
+	byteSize int
+
 	Stats CharacterStatsReset
 }
 
@@ -6009,6 +7095,11 @@ func (s StatSkillJunkServerPacket) Family() net.PacketFamily {
 
 func (s StatSkillJunkServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Junk
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *StatSkillJunkServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *StatSkillJunkServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6026,16 +7117,20 @@ func (s *StatSkillJunkServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Stats : field : CharacterStatsReset
 	if err = s.Stats.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemReplyServerPacket :: Reply to using an item.
 type ItemReplyServerPacket struct {
+	byteSize int
+
 	ItemType     pub.ItemType
 	UsedItem     net.Item
 	Weight       net.Weight
@@ -6047,9 +7142,16 @@ type ItemReplyItemTypeData interface {
 }
 
 type ItemReplyItemTypeDataHeal struct {
+	byteSize int
+
 	HpGain int
 	Hp     int
 	Tp     int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemReplyItemTypeDataHeal) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemReplyItemTypeDataHeal) Serialize(writer *data.EoWriter) (err error) {
@@ -6075,18 +7177,27 @@ func (s *ItemReplyItemTypeDataHeal) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// HpGain : field : int
 	s.HpGain = reader.GetInt()
 	// Hp : field : short
 	s.Hp = reader.GetShort()
 	// Tp : field : short
 	s.Tp = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type ItemReplyItemTypeDataHairDye struct {
+	byteSize int
+
 	HairColor int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemReplyItemTypeDataHairDye) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemReplyItemTypeDataHairDye) Serialize(writer *data.EoWriter) (err error) {
@@ -6104,14 +7215,23 @@ func (s *ItemReplyItemTypeDataHairDye) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// HairColor : field : char
 	s.HairColor = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type ItemReplyItemTypeDataEffectPotion struct {
+	byteSize int
+
 	EffectId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemReplyItemTypeDataEffectPotion) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemReplyItemTypeDataEffectPotion) Serialize(writer *data.EoWriter) (err error) {
@@ -6129,14 +7249,23 @@ func (s *ItemReplyItemTypeDataEffectPotion) Deserialize(reader *data.EoReader) (
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// EffectId : field : short
 	s.EffectId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type ItemReplyItemTypeDataCureCurse struct {
+	byteSize int
+
 	Stats CharacterStatsEquipmentChange
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemReplyItemTypeDataCureCurse) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemReplyItemTypeDataCureCurse) Serialize(writer *data.EoWriter) (err error) {
@@ -6154,15 +7283,19 @@ func (s *ItemReplyItemTypeDataCureCurse) Deserialize(reader *data.EoReader) (err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Stats : field : CharacterStatsEquipmentChange
 	if err = s.Stats.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type ItemReplyItemTypeDataExpReward struct {
+	byteSize int
+
 	Experience  int
 	LevelUp     int //  A value greater than 0 is "new level" and indicates the player leveled up.
 	StatPoints  int
@@ -6170,6 +7303,11 @@ type ItemReplyItemTypeDataExpReward struct {
 	MaxHp       int
 	MaxTp       int
 	MaxSp       int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemReplyItemTypeDataExpReward) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemReplyItemTypeDataExpReward) Serialize(writer *data.EoWriter) (err error) {
@@ -6211,6 +7349,7 @@ func (s *ItemReplyItemTypeDataExpReward) Deserialize(reader *data.EoReader) (err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Experience : field : int
 	s.Experience = reader.GetInt()
 	// LevelUp : field : char
@@ -6225,6 +7364,7 @@ func (s *ItemReplyItemTypeDataExpReward) Deserialize(reader *data.EoReader) (err
 	s.MaxTp = reader.GetShort()
 	// MaxSp : field : short
 	s.MaxSp = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -6235,6 +7375,11 @@ func (s ItemReplyServerPacket) Family() net.PacketFamily {
 
 func (s ItemReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6312,6 +7457,7 @@ func (s *ItemReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemType : field : ItemType
 	s.ItemType = pub.ItemType(reader.GetChar())
 	// UsedItem : field : Item
@@ -6349,12 +7495,15 @@ func (s *ItemReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemDropServerPacket :: Reply to dropping items on the ground.
 type ItemDropServerPacket struct {
+	byteSize int
+
 	DroppedItem     net.ThreeItem
 	RemainingAmount int
 	ItemIndex       int
@@ -6368,6 +7517,11 @@ func (s ItemDropServerPacket) Family() net.PacketFamily {
 
 func (s ItemDropServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Drop
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemDropServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemDropServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6401,6 +7555,7 @@ func (s *ItemDropServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// DroppedItem : field : ThreeItem
 	if err = s.DroppedItem.Deserialize(reader); err != nil {
 		return
@@ -6417,12 +7572,15 @@ func (s *ItemDropServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Weight.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemAddServerPacket :: Item appeared on the ground.
 type ItemAddServerPacket struct {
+	byteSize int
+
 	ItemId     int
 	ItemIndex  int
 	ItemAmount int
@@ -6435,6 +7593,11 @@ func (s ItemAddServerPacket) Family() net.PacketFamily {
 
 func (s ItemAddServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Add
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemAddServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemAddServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6464,6 +7627,7 @@ func (s *ItemAddServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
 	// ItemIndex : field : short
@@ -6474,12 +7638,15 @@ func (s *ItemAddServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemRemoveServerPacket :: Item disappeared from the ground.
 type ItemRemoveServerPacket struct {
+	byteSize int
+
 	ItemIndex int
 }
 
@@ -6489,6 +7656,11 @@ func (s ItemRemoveServerPacket) Family() net.PacketFamily {
 
 func (s ItemRemoveServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemRemoveServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6506,14 +7678,18 @@ func (s *ItemRemoveServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemIndex : field : short
 	s.ItemIndex = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemJunkServerPacket :: Reply to junking items.
 type ItemJunkServerPacket struct {
+	byteSize int
+
 	JunkedItem      net.ThreeItem
 	RemainingAmount int
 	Weight          net.Weight
@@ -6525,6 +7701,11 @@ func (s ItemJunkServerPacket) Family() net.PacketFamily {
 
 func (s ItemJunkServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Junk
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemJunkServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemJunkServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6550,6 +7731,7 @@ func (s *ItemJunkServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// JunkedItem : field : ThreeItem
 	if err = s.JunkedItem.Deserialize(reader); err != nil {
 		return
@@ -6560,12 +7742,15 @@ func (s *ItemJunkServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Weight.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemGetServerPacket :: Reply to taking items from the ground.
 type ItemGetServerPacket struct {
+	byteSize int
+
 	TakenItemIndex int
 	TakenItem      net.ThreeItem
 	Weight         net.Weight
@@ -6577,6 +7762,11 @@ func (s ItemGetServerPacket) Family() net.PacketFamily {
 
 func (s ItemGetServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Get
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemGetServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemGetServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6602,6 +7792,7 @@ func (s *ItemGetServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// TakenItemIndex : field : short
 	s.TakenItemIndex = reader.GetShort()
 	// TakenItem : field : ThreeItem
@@ -6612,12 +7803,15 @@ func (s *ItemGetServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Weight.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemObtainServerPacket :: Receive item (from quest).
 type ItemObtainServerPacket struct {
+	byteSize int
+
 	Item          net.ThreeItem
 	CurrentWeight int
 }
@@ -6628,6 +7822,11 @@ func (s ItemObtainServerPacket) Family() net.PacketFamily {
 
 func (s ItemObtainServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Obtain
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemObtainServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemObtainServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6649,18 +7848,22 @@ func (s *ItemObtainServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Item : field : ThreeItem
 	if err = s.Item.Deserialize(reader); err != nil {
 		return
 	}
 	// CurrentWeight : field : char
 	s.CurrentWeight = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemKickServerPacket :: Lose item (from quest).
 type ItemKickServerPacket struct {
+	byteSize int
+
 	Item          net.Item
 	CurrentWeight int
 }
@@ -6671,6 +7874,11 @@ func (s ItemKickServerPacket) Family() net.PacketFamily {
 
 func (s ItemKickServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Kick
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemKickServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemKickServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6692,18 +7900,22 @@ func (s *ItemKickServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Item : field : Item
 	if err = s.Item.Deserialize(reader); err != nil {
 		return
 	}
 	// CurrentWeight : field : char
 	s.CurrentWeight = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemAgreeServerPacket :: Reply to using an item that you don't have.
 type ItemAgreeServerPacket struct {
+	byteSize int
+
 	ItemId int
 }
 
@@ -6713,6 +7925,11 @@ func (s ItemAgreeServerPacket) Family() net.PacketFamily {
 
 func (s ItemAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6730,14 +7947,17 @@ func (s *ItemAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemSpecServerPacket :: Reply to trying to take a protected item from the ground.
 type ItemSpecServerPacket struct {
+	byteSize int
 }
 
 func (s ItemSpecServerPacket) Family() net.PacketFamily {
@@ -6746,6 +7966,11 @@ func (s ItemSpecServerPacket) Family() net.PacketFamily {
 
 func (s ItemSpecServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Spec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemSpecServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6763,14 +7988,18 @@ func (s *ItemSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 2 : dummy : short
 	reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BoardPlayerServerPacket :: Reply to reading a post on a town board.
 type BoardPlayerServerPacket struct {
+	byteSize int
+
 	PostId   int
 	PostBody string
 }
@@ -6781,6 +8010,11 @@ func (s BoardPlayerServerPacket) Family() net.PacketFamily {
 
 func (s BoardPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BoardPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BoardPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6804,6 +8038,7 @@ func (s *BoardPlayerServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PostId : field : short
 	s.PostId = reader.GetShort()
@@ -6813,12 +8048,15 @@ func (s *BoardPlayerServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BoardOpenServerPacket :: Reply to opening a town board.
 type BoardOpenServerPacket struct {
+	byteSize int
+
 	BoardId    int
 	PostsCount int
 	Posts      []BoardPostListing
@@ -6830,6 +8068,11 @@ func (s BoardOpenServerPacket) Family() net.PacketFamily {
 
 func (s BoardOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BoardOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BoardOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6861,6 +8104,7 @@ func (s *BoardOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// BoardId : field : char
 	s.BoardId = reader.GetChar()
@@ -6878,12 +8122,15 @@ func (s *BoardOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // JukeboxAgreeServerPacket :: Reply to successfully requesting a song.
 type JukeboxAgreeServerPacket struct {
+	byteSize int
+
 	GoldAmount int
 }
 
@@ -6893,6 +8140,11 @@ func (s JukeboxAgreeServerPacket) Family() net.PacketFamily {
 
 func (s JukeboxAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *JukeboxAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *JukeboxAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6910,14 +8162,17 @@ func (s *JukeboxAgreeServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // JukeboxReplyServerPacket :: Reply to unsuccessfully requesting a song.
 type JukeboxReplyServerPacket struct {
+	byteSize int
 }
 
 func (s JukeboxReplyServerPacket) Family() net.PacketFamily {
@@ -6926,6 +8181,11 @@ func (s JukeboxReplyServerPacket) Family() net.PacketFamily {
 
 func (s JukeboxReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *JukeboxReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *JukeboxReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6943,14 +8203,18 @@ func (s *JukeboxReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 1 : dummy : short
 	reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // JukeboxOpenServerPacket :: Reply to opening the jukebox listing.
 type JukeboxOpenServerPacket struct {
+	byteSize int
+
 	MapId         int
 	JukeboxPlayer string
 }
@@ -6961,6 +8225,11 @@ func (s JukeboxOpenServerPacket) Family() net.PacketFamily {
 
 func (s JukeboxOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *JukeboxOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *JukeboxOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -6982,6 +8251,7 @@ func (s *JukeboxOpenServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapId : field : short
 	s.MapId = reader.GetShort()
 	// JukeboxPlayer : field : string
@@ -6989,11 +8259,15 @@ func (s *JukeboxOpenServerPacket) Deserialize(reader *data.EoReader) (err error)
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // JukeboxMsgServerPacket :: Someone playing a note with the bard skill nearby.
 type JukeboxMsgServerPacket struct {
+	byteSize int
+
 	PlayerId     int
 	Direction    protocol.Direction
 	InstrumentId int
@@ -7006,6 +8280,11 @@ func (s JukeboxMsgServerPacket) Family() net.PacketFamily {
 
 func (s JukeboxMsgServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Msg
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *JukeboxMsgServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *JukeboxMsgServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7035,6 +8314,7 @@ func (s *JukeboxMsgServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Direction : field : Direction
@@ -7043,12 +8323,15 @@ func (s *JukeboxMsgServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	s.InstrumentId = reader.GetChar()
 	// NoteId : field : char
 	s.NoteId = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // JukeboxPlayerServerPacket :: Play background music.
 type JukeboxPlayerServerPacket struct {
+	byteSize int
+
 	MfxId int
 }
 
@@ -7058,6 +8341,11 @@ func (s JukeboxPlayerServerPacket) Family() net.PacketFamily {
 
 func (s JukeboxPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *JukeboxPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *JukeboxPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7075,14 +8363,18 @@ func (s *JukeboxPlayerServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MfxId : field : char
 	s.MfxId = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // JukeboxUseServerPacket :: Play jukebox music.
 type JukeboxUseServerPacket struct {
+	byteSize int
+
 	TrackId int // This value is 1-indexed.
 }
 
@@ -7092,6 +8384,11 @@ func (s JukeboxUseServerPacket) Family() net.PacketFamily {
 
 func (s JukeboxUseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *JukeboxUseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *JukeboxUseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7109,14 +8406,18 @@ func (s *JukeboxUseServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// TrackId : field : short
 	s.TrackId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WarpRequestServerPacket :: Warp request from server.
 type WarpRequestServerPacket struct {
+	byteSize int
+
 	WarpType     WarpType
 	MapId        int
 	WarpTypeData WarpRequestWarpTypeData
@@ -7128,8 +8429,15 @@ type WarpRequestWarpTypeData interface {
 }
 
 type WarpRequestWarpTypeDataMapSwitch struct {
+	byteSize int
+
 	MapRid      []int
 	MapFileSize int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WarpRequestWarpTypeDataMapSwitch) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WarpRequestWarpTypeDataMapSwitch) Serialize(writer *data.EoWriter) (err error) {
@@ -7154,6 +8462,7 @@ func (s *WarpRequestWarpTypeDataMapSwitch) Deserialize(reader *data.EoReader) (e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
 		s.MapRid = append(s.MapRid, 0)
@@ -7162,6 +8471,7 @@ func (s *WarpRequestWarpTypeDataMapSwitch) Deserialize(reader *data.EoReader) (e
 
 	// MapFileSize : field : three
 	s.MapFileSize = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -7172,6 +8482,11 @@ func (s WarpRequestServerPacket) Family() net.PacketFamily {
 
 func (s WarpRequestServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WarpRequestServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WarpRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7209,6 +8524,7 @@ func (s *WarpRequestServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// WarpType : field : WarpType
 	s.WarpType = WarpType(reader.GetChar())
 	// MapId : field : short
@@ -7222,12 +8538,15 @@ func (s *WarpRequestServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // WarpAgreeServerPacket :: Reply after accepting a warp.
 type WarpAgreeServerPacket struct {
+	byteSize int
+
 	WarpType     WarpType
 	WarpTypeData WarpAgreeWarpTypeData
 	Nearby       NearbyInfo
@@ -7238,8 +8557,15 @@ type WarpAgreeWarpTypeData interface {
 }
 
 type WarpAgreeWarpTypeDataMapSwitch struct {
+	byteSize int
+
 	MapId      int
 	WarpEffect WarpEffect
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WarpAgreeWarpTypeDataMapSwitch) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WarpAgreeWarpTypeDataMapSwitch) Serialize(writer *data.EoWriter) (err error) {
@@ -7261,10 +8587,12 @@ func (s *WarpAgreeWarpTypeDataMapSwitch) Deserialize(reader *data.EoReader) (err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapId : field : short
 	s.MapId = reader.GetShort()
 	// WarpEffect : field : WarpEffect
 	s.WarpEffect = WarpEffect(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -7275,6 +8603,11 @@ func (s WarpAgreeServerPacket) Family() net.PacketFamily {
 
 func (s WarpAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *WarpAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *WarpAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7310,6 +8643,7 @@ func (s *WarpAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// WarpType : field : WarpType
 	s.WarpType = WarpType(reader.GetChar())
@@ -7325,12 +8659,15 @@ func (s *WarpAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PaperdollReplyServerPacket :: Reply to requesting a paperdoll.
 type PaperdollReplyServerPacket struct {
+	byteSize int
+
 	Details   CharacterDetails
 	Equipment EquipmentPaperdoll
 	Icon      CharacterIcon
@@ -7342,6 +8679,11 @@ func (s PaperdollReplyServerPacket) Family() net.PacketFamily {
 
 func (s PaperdollReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PaperdollReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PaperdollReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7369,6 +8711,7 @@ func (s *PaperdollReplyServerPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Details : field : CharacterDetails
 	if err = s.Details.Deserialize(reader); err != nil {
@@ -7381,12 +8724,15 @@ func (s *PaperdollReplyServerPacket) Deserialize(reader *data.EoReader) (err err
 	// Icon : field : CharacterIcon
 	s.Icon = CharacterIcon(reader.GetChar())
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PaperdollPingServerPacket :: Failed to equip an item due to being the incorrect class.
 type PaperdollPingServerPacket struct {
+	byteSize int
+
 	ClassId int // The player's current class ID (not the item's required class ID).
 }
 
@@ -7396,6 +8742,11 @@ func (s PaperdollPingServerPacket) Family() net.PacketFamily {
 
 func (s PaperdollPingServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Ping
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PaperdollPingServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PaperdollPingServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7413,14 +8764,18 @@ func (s *PaperdollPingServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ClassId : field : char
 	s.ClassId = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PaperdollRemoveServerPacket :: Reply to unequipping an item.
 type PaperdollRemoveServerPacket struct {
+	byteSize int
+
 	Change AvatarChange
 	ItemId int
 	SubLoc int
@@ -7433,6 +8788,11 @@ func (s PaperdollRemoveServerPacket) Family() net.PacketFamily {
 
 func (s PaperdollRemoveServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PaperdollRemoveServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PaperdollRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7462,6 +8822,7 @@ func (s *PaperdollRemoveServerPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Change : field : AvatarChange
 	if err = s.Change.Deserialize(reader); err != nil {
 		return
@@ -7474,12 +8835,15 @@ func (s *PaperdollRemoveServerPacket) Deserialize(reader *data.EoReader) (err er
 	if err = s.Stats.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PaperdollAgreeServerPacket :: Reply to equipping an item.
 type PaperdollAgreeServerPacket struct {
+	byteSize int
+
 	Change          AvatarChange
 	ItemId          int
 	RemainingAmount int
@@ -7493,6 +8857,11 @@ func (s PaperdollAgreeServerPacket) Family() net.PacketFamily {
 
 func (s PaperdollAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PaperdollAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PaperdollAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7526,6 +8895,7 @@ func (s *PaperdollAgreeServerPacket) Deserialize(reader *data.EoReader) (err err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Change : field : AvatarChange
 	if err = s.Change.Deserialize(reader); err != nil {
 		return
@@ -7540,12 +8910,15 @@ func (s *PaperdollAgreeServerPacket) Deserialize(reader *data.EoReader) (err err
 	if err = s.Stats.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AvatarAgreeServerPacket :: Nearby player changed appearance.
 type AvatarAgreeServerPacket struct {
+	byteSize int
+
 	Change AvatarChange
 }
 
@@ -7555,6 +8928,11 @@ func (s AvatarAgreeServerPacket) Family() net.PacketFamily {
 
 func (s AvatarAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AvatarAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AvatarAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7572,16 +8950,20 @@ func (s *AvatarAgreeServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Change : field : AvatarChange
 	if err = s.Change.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BookReplyServerPacket :: Reply to requesting a book.
 type BookReplyServerPacket struct {
+	byteSize int
+
 	Details    CharacterDetails
 	Icon       CharacterIcon
 	QuestNames []string
@@ -7593,6 +8975,11 @@ func (s BookReplyServerPacket) Family() net.PacketFamily {
 
 func (s BookReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BookReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BookReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7625,6 +9012,7 @@ func (s *BookReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Details : field : CharacterDetails
 	if err = s.Details.Deserialize(reader); err != nil {
@@ -7648,12 +9036,14 @@ func (s *BookReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MessagePongServerPacket :: #ping command reply.
 type MessagePongServerPacket struct {
+	byteSize int
 }
 
 func (s MessagePongServerPacket) Family() net.PacketFamily {
@@ -7662,6 +9052,11 @@ func (s MessagePongServerPacket) Family() net.PacketFamily {
 
 func (s MessagePongServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Pong
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MessagePongServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MessagePongServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7679,14 +9074,18 @@ func (s *MessagePongServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 2 : dummy : short
 	reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersPingServerPacket :: #find command reply - offline.
 type PlayersPingServerPacket struct {
+	byteSize int
+
 	Name string
 }
 
@@ -7696,6 +9095,11 @@ func (s PlayersPingServerPacket) Family() net.PacketFamily {
 
 func (s PlayersPingServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Ping
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersPingServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersPingServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7713,16 +9117,21 @@ func (s *PlayersPingServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersPongServerPacket :: #find command reply - same map.
 type PlayersPongServerPacket struct {
+	byteSize int
+
 	Name string
 }
 
@@ -7732,6 +9141,11 @@ func (s PlayersPongServerPacket) Family() net.PacketFamily {
 
 func (s PlayersPongServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Pong
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersPongServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersPongServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7749,16 +9163,21 @@ func (s *PlayersPongServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersNet242ServerPacket :: #find command reply - different map.
 type PlayersNet242ServerPacket struct {
+	byteSize int
+
 	Name string
 }
 
@@ -7768,6 +9187,11 @@ func (s PlayersNet242ServerPacket) Family() net.PacketFamily {
 
 func (s PlayersNet242ServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Net242
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersNet242ServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersNet242ServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7785,16 +9209,21 @@ func (s *PlayersNet242ServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // DoorOpenServerPacket :: Nearby door opening.
 type DoorOpenServerPacket struct {
+	byteSize int
+
 	Coords protocol.Coords
 }
 
@@ -7804,6 +9233,11 @@ func (s DoorOpenServerPacket) Family() net.PacketFamily {
 
 func (s DoorOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *DoorOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *DoorOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7825,18 +9259,22 @@ func (s *DoorOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
 	// 0 : field : char
 	reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // DoorCloseServerPacket :: Reply to trying to open a locked door.
 type DoorCloseServerPacket struct {
+	byteSize int
+
 	Key int
 }
 
@@ -7846,6 +9284,11 @@ func (s DoorCloseServerPacket) Family() net.PacketFamily {
 
 func (s DoorCloseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Close
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *DoorCloseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *DoorCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7863,14 +9306,18 @@ func (s *DoorCloseServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Key : field : char
 	s.Key = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ChestOpenServerPacket :: Reply to opening a chest.
 type ChestOpenServerPacket struct {
+	byteSize int
+
 	Coords protocol.Coords
 	Items  []net.ThreeItem
 }
@@ -7881,6 +9328,11 @@ func (s ChestOpenServerPacket) Family() net.PacketFamily {
 
 func (s ChestOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChestOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChestOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7905,6 +9357,7 @@ func (s *ChestOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
@@ -7917,11 +9370,15 @@ func (s *ChestOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // ChestReplyServerPacket :: Reply to placing an item in to a chest.
 type ChestReplyServerPacket struct {
+	byteSize int
+
 	AddedItemId     int
 	RemainingAmount int
 	Weight          net.Weight
@@ -7934,6 +9391,11 @@ func (s ChestReplyServerPacket) Family() net.PacketFamily {
 
 func (s ChestReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChestReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChestReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -7966,6 +9428,7 @@ func (s *ChestReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// AddedItemId : field : short
 	s.AddedItemId = reader.GetShort()
 	// RemainingAmount : field : int
@@ -7982,11 +9445,15 @@ func (s *ChestReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // ChestGetServerPacket :: Reply to removing an item from a chest.
 type ChestGetServerPacket struct {
+	byteSize int
+
 	TakenItem net.ThreeItem
 	Weight    net.Weight
 	Items     []net.ThreeItem
@@ -7998,6 +9465,11 @@ func (s ChestGetServerPacket) Family() net.PacketFamily {
 
 func (s ChestGetServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Get
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChestGetServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChestGetServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8026,6 +9498,7 @@ func (s *ChestGetServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// TakenItem : field : ThreeItem
 	if err = s.TakenItem.Deserialize(reader); err != nil {
 		return
@@ -8042,11 +9515,15 @@ func (s *ChestGetServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // ChestAgreeServerPacket :: Chest contents updating.
 type ChestAgreeServerPacket struct {
+	byteSize int
+
 	Items []net.ThreeItem
 }
 
@@ -8056,6 +9533,11 @@ func (s ChestAgreeServerPacket) Family() net.PacketFamily {
 
 func (s ChestAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChestAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChestAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8076,6 +9558,7 @@ func (s *ChestAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Items : array : ThreeItem
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
 		s.Items = append(s.Items, net.ThreeItem{})
@@ -8084,11 +9567,14 @@ func (s *ChestAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) 
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // ChestSpecServerPacket :: Reply to trying to add an item to a full chest.
 type ChestSpecServerPacket struct {
+	byteSize int
 }
 
 func (s ChestSpecServerPacket) Family() net.PacketFamily {
@@ -8097,6 +9583,11 @@ func (s ChestSpecServerPacket) Family() net.PacketFamily {
 
 func (s ChestSpecServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Spec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChestSpecServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChestSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8114,14 +9605,18 @@ func (s *ChestSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 0 : dummy : byte
 	reader.GetByte()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ChestCloseServerPacket ::  Reply to trying to interact with a locked or "broken" chest. The official client assumes a broken chest if the packet is under 2 bytes in length.
 type ChestCloseServerPacket struct {
+	byteSize int
+
 	Key *int // Sent if the player is trying to interact with a locked chest.
 }
 
@@ -8131,6 +9626,11 @@ func (s ChestCloseServerPacket) Family() net.PacketFamily {
 
 func (s ChestCloseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Close
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChestCloseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChestCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8154,6 +9654,7 @@ func (s *ChestCloseServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Key : field : short
 	if reader.Remaining() > 0 {
 		s.Key = new(int)
@@ -8163,12 +9664,15 @@ func (s *ChestCloseServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // RefreshReplyServerPacket :: Reply to request for new info about nearby objects.
 type RefreshReplyServerPacket struct {
+	byteSize int
+
 	Nearby NearbyInfo
 }
 
@@ -8178,6 +9682,11 @@ func (s RefreshReplyServerPacket) Family() net.PacketFamily {
 
 func (s RefreshReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *RefreshReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *RefreshReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8195,16 +9704,20 @@ func (s *RefreshReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Nearby : field : NearbyInfo
 	if err = s.Nearby.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyRequestServerPacket :: Received party invite / join request.
 type PartyRequestServerPacket struct {
+	byteSize int
+
 	RequestType     net.PartyRequestType
 	InviterPlayerId int
 	PlayerName      string
@@ -8216,6 +9729,11 @@ func (s PartyRequestServerPacket) Family() net.PacketFamily {
 
 func (s PartyRequestServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyRequestServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8241,6 +9759,7 @@ func (s *PartyRequestServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// RequestType : field : PartyRequestType
 	s.RequestType = net.PartyRequestType(reader.GetChar())
 	// InviterPlayerId : field : short
@@ -8250,11 +9769,15 @@ func (s *PartyRequestServerPacket) Deserialize(reader *data.EoReader) (err error
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // PartyReplyServerPacket :: Failed party invite / join request.
 type PartyReplyServerPacket struct {
+	byteSize int
+
 	ReplyCode     PartyReplyCode
 	ReplyCodeData PartyReplyReplyCodeData
 }
@@ -8264,7 +9787,14 @@ type PartyReplyReplyCodeData interface {
 }
 
 type PartyReplyReplyCodeDataAlreadyInAnotherParty struct {
+	byteSize int
+
 	PlayerName string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyReplyReplyCodeDataAlreadyInAnotherParty) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyReplyReplyCodeDataAlreadyInAnotherParty) Serialize(writer *data.EoWriter) (err error) {
@@ -8282,16 +9812,26 @@ func (s *PartyReplyReplyCodeDataAlreadyInAnotherParty) Deserialize(reader *data.
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerName : field : string
 	if s.PlayerName, err = reader.GetString(); err != nil {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 type PartyReplyReplyCodeDataAlreadyInYourParty struct {
+	byteSize int
+
 	PlayerName string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyReplyReplyCodeDataAlreadyInYourParty) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyReplyReplyCodeDataAlreadyInYourParty) Serialize(writer *data.EoWriter) (err error) {
@@ -8309,10 +9849,13 @@ func (s *PartyReplyReplyCodeDataAlreadyInYourParty) Deserialize(reader *data.EoR
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerName : field : string
 	if s.PlayerName, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -8323,6 +9866,11 @@ func (s PartyReplyServerPacket) Family() net.PacketFamily {
 
 func (s PartyReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8362,6 +9910,7 @@ func (s *PartyReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ReplyCode : field : PartyReplyCode
 	s.ReplyCode = PartyReplyCode(reader.GetChar())
 	switch s.ReplyCode {
@@ -8376,12 +9925,15 @@ func (s *PartyReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyCreateServerPacket :: Member list received when party is first joined.
 type PartyCreateServerPacket struct {
+	byteSize int
+
 	Members []PartyMember
 }
 
@@ -8391,6 +9943,11 @@ func (s PartyCreateServerPacket) Family() net.PacketFamily {
 
 func (s PartyCreateServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Create
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyCreateServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyCreateServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8414,6 +9971,7 @@ func (s *PartyCreateServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Members : array : PartyMember
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
@@ -8427,12 +9985,15 @@ func (s *PartyCreateServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyAddServerPacket :: New player joined the party.
 type PartyAddServerPacket struct {
+	byteSize int
+
 	Member PartyMember
 }
 
@@ -8442,6 +10003,11 @@ func (s PartyAddServerPacket) Family() net.PacketFamily {
 
 func (s PartyAddServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Add
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyAddServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyAddServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8459,16 +10025,20 @@ func (s *PartyAddServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Member : field : PartyMember
 	if err = s.Member.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyRemoveServerPacket :: Player left the party.
 type PartyRemoveServerPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -8478,6 +10048,11 @@ func (s PartyRemoveServerPacket) Family() net.PacketFamily {
 
 func (s PartyRemoveServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Remove
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyRemoveServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyRemoveServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8495,14 +10070,17 @@ func (s *PartyRemoveServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyCloseServerPacket :: Left / disbanded a party.
 type PartyCloseServerPacket struct {
+	byteSize int
 }
 
 func (s PartyCloseServerPacket) Family() net.PacketFamily {
@@ -8511,6 +10089,11 @@ func (s PartyCloseServerPacket) Family() net.PacketFamily {
 
 func (s PartyCloseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Close
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyCloseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8528,14 +10111,18 @@ func (s *PartyCloseServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 255 : dummy : byte
 	reader.GetByte()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyListServerPacket :: Party member list update.
 type PartyListServerPacket struct {
+	byteSize int
+
 	Members []PartyMember
 }
 
@@ -8545,6 +10132,11 @@ func (s PartyListServerPacket) Family() net.PacketFamily {
 
 func (s PartyListServerPacket) Action() net.PacketAction {
 	return net.PacketAction_List
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyListServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyListServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8568,6 +10160,7 @@ func (s *PartyListServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Members : array : PartyMember
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
@@ -8581,12 +10174,15 @@ func (s *PartyListServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyAgreeServerPacket :: Party member list update.
 type PartyAgreeServerPacket struct {
+	byteSize int
+
 	PlayerId     int
 	HpPercentage int
 }
@@ -8597,6 +10193,11 @@ func (s PartyAgreeServerPacket) Family() net.PacketFamily {
 
 func (s PartyAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8618,16 +10219,20 @@ func (s *PartyAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// HpPercentage : field : char
 	s.HpPercentage = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyTargetGroupServerPacket :: Updated experience and level-ups from party experience.
 type PartyTargetGroupServerPacket struct {
+	byteSize int
+
 	Gains []PartyExpShare
 }
 
@@ -8637,6 +10242,11 @@ func (s PartyTargetGroupServerPacket) Family() net.PacketFamily {
 
 func (s PartyTargetGroupServerPacket) Action() net.PacketAction {
 	return net.PacketAction_TargetGroup
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyTargetGroupServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyTargetGroupServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8657,6 +10267,7 @@ func (s *PartyTargetGroupServerPacket) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Gains : array : PartyExpShare
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
 		s.Gains = append(s.Gains, PartyExpShare{})
@@ -8665,11 +10276,15 @@ func (s *PartyTargetGroupServerPacket) Deserialize(reader *data.EoReader) (err e
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // GuildReplyServerPacket :: Generic guild reply messages.
 type GuildReplyServerPacket struct {
+	byteSize int
+
 	ReplyCode     GuildReply
 	ReplyCodeData GuildReplyReplyCodeData
 }
@@ -8679,7 +10294,14 @@ type GuildReplyReplyCodeData interface {
 }
 
 type GuildReplyReplyCodeDataCreateAdd struct {
+	byteSize int
+
 	Name string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildReplyReplyCodeDataCreateAdd) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildReplyReplyCodeDataCreateAdd) Serialize(writer *data.EoWriter) (err error) {
@@ -8697,16 +10319,26 @@ func (s *GuildReplyReplyCodeDataCreateAdd) Deserialize(reader *data.EoReader) (e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 type GuildReplyReplyCodeDataCreateAddConfirm struct {
+	byteSize int
+
 	Name string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildReplyReplyCodeDataCreateAddConfirm) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildReplyReplyCodeDataCreateAddConfirm) Serialize(writer *data.EoWriter) (err error) {
@@ -8724,17 +10356,27 @@ func (s *GuildReplyReplyCodeDataCreateAddConfirm) Deserialize(reader *data.EoRea
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 type GuildReplyReplyCodeDataJoinRequest struct {
+	byteSize int
+
 	PlayerId int
 	Name     string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildReplyReplyCodeDataJoinRequest) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildReplyReplyCodeDataJoinRequest) Serialize(writer *data.EoWriter) (err error) {
@@ -8756,12 +10398,15 @@ func (s *GuildReplyReplyCodeDataJoinRequest) Deserialize(reader *data.EoReader) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -8772,6 +10417,11 @@ func (s GuildReplyServerPacket) Family() net.PacketFamily {
 
 func (s GuildReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8821,6 +10471,7 @@ func (s *GuildReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ReplyCode : field : GuildReply
 	s.ReplyCode = GuildReply(reader.GetShort())
 	switch s.ReplyCode {
@@ -8840,12 +10491,15 @@ func (s *GuildReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildRequestServerPacket :: Guild create request.
 type GuildRequestServerPacket struct {
+	byteSize int
+
 	PlayerId      int
 	GuildIdentity string
 }
@@ -8856,6 +10510,11 @@ func (s GuildRequestServerPacket) Family() net.PacketFamily {
 
 func (s GuildRequestServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildRequestServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8877,6 +10536,7 @@ func (s *GuildRequestServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// GuildIdentity : field : string
@@ -8884,11 +10544,15 @@ func (s *GuildRequestServerPacket) Deserialize(reader *data.EoReader) (err error
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // GuildCreateServerPacket :: Guild created.
 type GuildCreateServerPacket struct {
+	byteSize int
+
 	LeaderPlayerId int
 	GuildTag       string
 	GuildName      string
@@ -8902,6 +10566,11 @@ func (s GuildCreateServerPacket) Family() net.PacketFamily {
 
 func (s GuildCreateServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Create
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildCreateServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildCreateServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -8941,6 +10610,7 @@ func (s *GuildCreateServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// LeaderPlayerId : field : short
 	s.LeaderPlayerId = reader.GetShort()
@@ -8974,12 +10644,15 @@ func (s *GuildCreateServerPacket) Deserialize(reader *data.EoReader) (err error)
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildTakeServerPacket :: Get guild description reply.
 type GuildTakeServerPacket struct {
+	byteSize int
+
 	Description string
 }
 
@@ -8989,6 +10662,11 @@ func (s GuildTakeServerPacket) Family() net.PacketFamily {
 
 func (s GuildTakeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Take
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildTakeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildTakeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9006,16 +10684,21 @@ func (s *GuildTakeServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Description : field : string
 	if s.Description, err = reader.GetString(); err != nil {
 		return
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildRankServerPacket :: Get guild rank list reply.
 type GuildRankServerPacket struct {
+	byteSize int
+
 	Ranks []string
 }
 
@@ -9025,6 +10708,11 @@ func (s GuildRankServerPacket) Family() net.PacketFamily {
 
 func (s GuildRankServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Rank
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildRankServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildRankServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9048,6 +10736,7 @@ func (s *GuildRankServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Ranks : array : string
 	for ndx := 0; ndx < 9; ndx++ {
@@ -9062,12 +10751,15 @@ func (s *GuildRankServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildSellServerPacket :: Get guild bank reply.
 type GuildSellServerPacket struct {
+	byteSize int
+
 	GoldAmount int
 }
 
@@ -9077,6 +10769,11 @@ func (s GuildSellServerPacket) Family() net.PacketFamily {
 
 func (s GuildSellServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Sell
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildSellServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildSellServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9094,14 +10791,18 @@ func (s *GuildSellServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildBuyServerPacket :: Deposit guild bank reply.
 type GuildBuyServerPacket struct {
+	byteSize int
+
 	GoldAmount int
 }
 
@@ -9111,6 +10812,11 @@ func (s GuildBuyServerPacket) Family() net.PacketFamily {
 
 func (s GuildBuyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Buy
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildBuyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildBuyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9128,14 +10834,18 @@ func (s *GuildBuyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildOpenServerPacket :: Talk to guild master NPC reply.
 type GuildOpenServerPacket struct {
+	byteSize int
+
 	SessionId int
 }
 
@@ -9145,6 +10855,11 @@ func (s GuildOpenServerPacket) Family() net.PacketFamily {
 
 func (s GuildOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9162,14 +10877,18 @@ func (s *GuildOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : three
 	s.SessionId = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildTellServerPacket :: Get guild member list reply.
 type GuildTellServerPacket struct {
+	byteSize int
+
 	MembersCount int
 	Members      []GuildMember
 }
@@ -9180,6 +10899,11 @@ func (s GuildTellServerPacket) Family() net.PacketFamily {
 
 func (s GuildTellServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Tell
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildTellServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildTellServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9208,6 +10932,7 @@ func (s *GuildTellServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// MembersCount : length : short
 	s.MembersCount = reader.GetShort()
@@ -9226,12 +10951,15 @@ func (s *GuildTellServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildReportServerPacket :: Get guild info reply.
 type GuildReportServerPacket struct {
+	byteSize int
+
 	Name        string
 	Tag         string
 	CreateDate  string
@@ -9248,6 +10976,11 @@ func (s GuildReportServerPacket) Family() net.PacketFamily {
 
 func (s GuildReportServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Report
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildReportServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildReportServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9309,6 +11042,7 @@ func (s *GuildReportServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
@@ -9379,12 +11113,15 @@ func (s *GuildReportServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildAgreeServerPacket :: Joined guild info.
 type GuildAgreeServerPacket struct {
+	byteSize int
+
 	RecruiterId int
 	GuildTag    string
 	GuildName   string
@@ -9397,6 +11134,11 @@ func (s GuildAgreeServerPacket) Family() net.PacketFamily {
 
 func (s GuildAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9432,6 +11174,7 @@ func (s *GuildAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// RecruiterId : field : short
 	s.RecruiterId = reader.GetShort()
@@ -9463,12 +11206,15 @@ func (s *GuildAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) 
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildAcceptServerPacket :: Update guild rank.
 type GuildAcceptServerPacket struct {
+	byteSize int
+
 	Rank int
 }
 
@@ -9478,6 +11224,11 @@ func (s GuildAcceptServerPacket) Family() net.PacketFamily {
 
 func (s GuildAcceptServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildAcceptServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9495,14 +11246,17 @@ func (s *GuildAcceptServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Rank : field : char
 	s.Rank = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildKickServerPacket :: Left the guild.
 type GuildKickServerPacket struct {
+	byteSize int
 }
 
 func (s GuildKickServerPacket) Family() net.PacketFamily {
@@ -9511,6 +11265,11 @@ func (s GuildKickServerPacket) Family() net.PacketFamily {
 
 func (s GuildKickServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Kick
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildKickServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildKickServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9528,14 +11287,18 @@ func (s *GuildKickServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 255 : dummy : byte
 	reader.GetByte()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SpellRequestServerPacket :: Nearby player chanting a spell.
 type SpellRequestServerPacket struct {
+	byteSize int
+
 	PlayerId int
 	SpellId  int
 }
@@ -9546,6 +11309,11 @@ func (s SpellRequestServerPacket) Family() net.PacketFamily {
 
 func (s SpellRequestServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellRequestServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9567,16 +11335,20 @@ func (s *SpellRequestServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SpellTargetSelfServerPacket :: Nearby player self-casted a spell.
 type SpellTargetSelfServerPacket struct {
+	byteSize int
+
 	PlayerId     int
 	SpellId      int
 	SpellHealHp  int
@@ -9591,6 +11363,11 @@ func (s SpellTargetSelfServerPacket) Family() net.PacketFamily {
 
 func (s SpellTargetSelfServerPacket) Action() net.PacketAction {
 	return net.PacketAction_TargetSelf
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellTargetSelfServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellTargetSelfServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9632,6 +11409,7 @@ func (s *SpellTargetSelfServerPacket) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// SpellId : field : short
@@ -9650,12 +11428,15 @@ func (s *SpellTargetSelfServerPacket) Deserialize(reader *data.EoReader) (err er
 		s.Tp = new(int)
 		*s.Tp = reader.GetShort()
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SpellPlayerServerPacket :: Nearby player raising their arm to cast a spell (vestigial).
 type SpellPlayerServerPacket struct {
+	byteSize int
+
 	PlayerId  int
 	Direction protocol.Direction
 }
@@ -9666,6 +11447,11 @@ func (s SpellPlayerServerPacket) Family() net.PacketFamily {
 
 func (s SpellPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9687,16 +11473,19 @@ func (s *SpellPlayerServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SpellErrorServerPacket :: Show flood protection message (vestigial).
 type SpellErrorServerPacket struct {
+	byteSize int
 }
 
 func (s SpellErrorServerPacket) Family() net.PacketFamily {
@@ -9705,6 +11494,11 @@ func (s SpellErrorServerPacket) Family() net.PacketFamily {
 
 func (s SpellErrorServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Error
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellErrorServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellErrorServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9722,14 +11516,18 @@ func (s *SpellErrorServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 255 : dummy : byte
 	reader.GetByte()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AvatarAdminServerPacket :: Nearby player hit by a damage spell from a player.
 type AvatarAdminServerPacket struct {
+	byteSize int
+
 	CasterId        int
 	VictimId        int
 	Damage          int
@@ -9745,6 +11543,11 @@ func (s AvatarAdminServerPacket) Family() net.PacketFamily {
 
 func (s AvatarAdminServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Admin
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AvatarAdminServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AvatarAdminServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9792,6 +11595,7 @@ func (s *AvatarAdminServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CasterId : field : short
 	s.CasterId = reader.GetShort()
 	// VictimId : field : short
@@ -9810,12 +11614,15 @@ func (s *AvatarAdminServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SpellTargetGroupServerPacket :: Nearby player(s) hit by a group heal spell from a player.
 type SpellTargetGroupServerPacket struct {
+	byteSize int
+
 	SpellId     int
 	CasterId    int
 	CasterTp    int
@@ -9829,6 +11636,11 @@ func (s SpellTargetGroupServerPacket) Family() net.PacketFamily {
 
 func (s SpellTargetGroupServerPacket) Action() net.PacketAction {
 	return net.PacketAction_TargetGroup
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellTargetGroupServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellTargetGroupServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9865,6 +11677,7 @@ func (s *SpellTargetGroupServerPacket) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
 	// CasterId : field : short
@@ -9881,11 +11694,15 @@ func (s *SpellTargetGroupServerPacket) Deserialize(reader *data.EoReader) (err e
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // SpellTargetOtherServerPacket :: Nearby player hit by a heal spell from a player.
 type SpellTargetOtherServerPacket struct {
+	byteSize int
+
 	VictimId        int
 	CasterId        int
 	CasterDirection protocol.Direction
@@ -9901,6 +11718,11 @@ func (s SpellTargetOtherServerPacket) Family() net.PacketFamily {
 
 func (s SpellTargetOtherServerPacket) Action() net.PacketAction {
 	return net.PacketAction_TargetOther
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellTargetOtherServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SpellTargetOtherServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -9944,6 +11766,7 @@ func (s *SpellTargetOtherServerPacket) Deserialize(reader *data.EoReader) (err e
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// VictimId : field : short
 	s.VictimId = reader.GetShort()
 	// CasterId : field : short
@@ -9961,12 +11784,15 @@ func (s *SpellTargetOtherServerPacket) Deserialize(reader *data.EoReader) (err e
 		s.Hp = new(int)
 		*s.Hp = reader.GetShort()
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeRequestServerPacket :: Trade request from another player.
 type TradeRequestServerPacket struct {
+	byteSize int
+
 	PartnerPlayerId   int
 	PartnerPlayerName string
 }
@@ -9977,6 +11803,11 @@ func (s TradeRequestServerPacket) Family() net.PacketFamily {
 
 func (s TradeRequestServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeRequestServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10002,6 +11833,7 @@ func (s *TradeRequestServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// 138 : field : char
 	reader.GetChar()
 	// PartnerPlayerId : field : short
@@ -10011,11 +11843,15 @@ func (s *TradeRequestServerPacket) Deserialize(reader *data.EoReader) (err error
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // TradeOpenServerPacket :: Trade window opens.
 type TradeOpenServerPacket struct {
+	byteSize int
+
 	PartnerPlayerId   int
 	PartnerPlayerName string
 	YourPlayerId      int
@@ -10028,6 +11864,11 @@ func (s TradeOpenServerPacket) Family() net.PacketFamily {
 
 func (s TradeOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10061,6 +11902,7 @@ func (s *TradeOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PartnerPlayerId : field : short
 	s.PartnerPlayerId = reader.GetShort()
@@ -10083,12 +11925,15 @@ func (s *TradeOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeReplyServerPacket :: Trade updated (items changed).
 type TradeReplyServerPacket struct {
+	byteSize int
+
 	TradeData TradeItemData
 }
 
@@ -10098,6 +11943,11 @@ func (s TradeReplyServerPacket) Family() net.PacketFamily {
 
 func (s TradeReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10115,16 +11965,20 @@ func (s *TradeReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// TradeData : field : TradeItemData
 	if err = s.TradeData.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeAdminServerPacket :: Trade updated (items changed while trade was accepted).
 type TradeAdminServerPacket struct {
+	byteSize int
+
 	TradeData TradeItemData
 }
 
@@ -10134,6 +11988,11 @@ func (s TradeAdminServerPacket) Family() net.PacketFamily {
 
 func (s TradeAdminServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Admin
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeAdminServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeAdminServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10151,16 +12010,20 @@ func (s *TradeAdminServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// TradeData : field : TradeItemData
 	if err = s.TradeData.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeUseServerPacket :: Trade completed.
 type TradeUseServerPacket struct {
+	byteSize int
+
 	TradeData TradeItemData
 }
 
@@ -10170,6 +12033,11 @@ func (s TradeUseServerPacket) Family() net.PacketFamily {
 
 func (s TradeUseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeUseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeUseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10187,16 +12055,20 @@ func (s *TradeUseServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// TradeData : field : TradeItemData
 	if err = s.TradeData.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeSpecServerPacket :: Own agree state updated.
 type TradeSpecServerPacket struct {
+	byteSize int
+
 	Agree bool
 }
 
@@ -10206,6 +12078,11 @@ func (s TradeSpecServerPacket) Family() net.PacketFamily {
 
 func (s TradeSpecServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Spec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeSpecServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10229,18 +12106,22 @@ func (s *TradeSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Agree : field : bool
 	if boolVal := reader.GetChar(); boolVal > 0 {
 		s.Agree = true
 	} else {
 		s.Agree = false
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeAgreeServerPacket :: Partner agree state updated.
 type TradeAgreeServerPacket struct {
+	byteSize int
+
 	PartnerPlayerId int
 	Agree           bool
 }
@@ -10251,6 +12132,11 @@ func (s TradeAgreeServerPacket) Family() net.PacketFamily {
 
 func (s TradeAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10278,6 +12164,7 @@ func (s *TradeAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PartnerPlayerId : field : short
 	s.PartnerPlayerId = reader.GetShort()
 	// Agree : field : bool
@@ -10286,12 +12173,15 @@ func (s *TradeAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	} else {
 		s.Agree = false
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeCloseServerPacket :: Partner closed trade window.
 type TradeCloseServerPacket struct {
+	byteSize int
+
 	PartnerPlayerId int
 }
 
@@ -10301,6 +12191,11 @@ func (s TradeCloseServerPacket) Family() net.PacketFamily {
 
 func (s TradeCloseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Close
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeCloseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeCloseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10318,14 +12213,18 @@ func (s *TradeCloseServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PartnerPlayerId : field : short
 	s.PartnerPlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcReplyServerPacket :: Nearby NPC hit by a player.
 type NpcReplyServerPacket struct {
+	byteSize int
+
 	PlayerId            int
 	PlayerDirection     protocol.Direction
 	NpcIndex            int
@@ -10340,6 +12239,11 @@ func (s NpcReplyServerPacket) Family() net.PacketFamily {
 
 func (s NpcReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10379,6 +12283,7 @@ func (s *NpcReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// PlayerDirection : field : Direction
@@ -10394,12 +12299,15 @@ func (s *NpcReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		s.KillStealProtection = new(NpcKillStealProtectionState)
 		*s.KillStealProtection = NpcKillStealProtectionState(reader.GetChar())
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CastReplyServerPacket :: Nearby NPC hit by a spell from a player.
 type CastReplyServerPacket struct {
+	byteSize int
+
 	SpellId             int
 	CasterId            int
 	CasterDirection     protocol.Direction
@@ -10416,6 +12324,11 @@ func (s CastReplyServerPacket) Family() net.PacketFamily {
 
 func (s CastReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CastReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CastReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10463,6 +12376,7 @@ func (s *CastReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
 	// CasterId : field : short
@@ -10482,12 +12396,15 @@ func (s *CastReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		s.KillStealProtection = new(NpcKillStealProtectionState)
 		*s.KillStealProtection = NpcKillStealProtectionState(reader.GetChar())
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcSpecServerPacket :: Nearby NPC killed by player.
 type NpcSpecServerPacket struct {
+	byteSize int
+
 	NpcKilledData NpcKilledData
 	Experience    *int
 }
@@ -10498,6 +12415,11 @@ func (s NpcSpecServerPacket) Family() net.PacketFamily {
 
 func (s NpcSpecServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Spec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcSpecServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10521,6 +12443,7 @@ func (s *NpcSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcKilledData : field : NpcKilledData
 	if err = s.NpcKilledData.Deserialize(reader); err != nil {
 		return
@@ -10530,12 +12453,15 @@ func (s *NpcSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		s.Experience = new(int)
 		*s.Experience = reader.GetInt()
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcAcceptServerPacket :: Nearby NPC killed by player and you leveled up.
 type NpcAcceptServerPacket struct {
+	byteSize int
+
 	NpcKilledData NpcKilledData
 	Experience    int
 	LevelUp       LevelUpStats
@@ -10547,6 +12473,11 @@ func (s NpcAcceptServerPacket) Family() net.PacketFamily {
 
 func (s NpcAcceptServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcAcceptServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10572,6 +12503,7 @@ func (s *NpcAcceptServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcKilledData : field : NpcKilledData
 	if err = s.NpcKilledData.Deserialize(reader); err != nil {
 		return
@@ -10582,12 +12514,15 @@ func (s *NpcAcceptServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.LevelUp.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CastSpecServerPacket :: Nearby NPC killed by player spell.
 type CastSpecServerPacket struct {
+	byteSize int
+
 	SpellId       int
 	NpcKilledData NpcKilledData
 	CasterTp      int
@@ -10600,6 +12535,11 @@ func (s CastSpecServerPacket) Family() net.PacketFamily {
 
 func (s CastSpecServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Spec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CastSpecServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CastSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10631,6 +12571,7 @@ func (s *CastSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
 	// NpcKilledData : field : NpcKilledData
@@ -10644,12 +12585,15 @@ func (s *CastSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		s.Experience = new(int)
 		*s.Experience = reader.GetInt()
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CastAcceptServerPacket :: Nearby NPC killed by player spell and you leveled up.
 type CastAcceptServerPacket struct {
+	byteSize int
+
 	SpellId       int
 	NpcKilledData NpcKilledData
 	CasterTp      int
@@ -10663,6 +12607,11 @@ func (s CastAcceptServerPacket) Family() net.PacketFamily {
 
 func (s CastAcceptServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CastAcceptServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CastAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10696,6 +12645,7 @@ func (s *CastAcceptServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SpellId : field : short
 	s.SpellId = reader.GetShort()
 	// NpcKilledData : field : NpcKilledData
@@ -10710,12 +12660,15 @@ func (s *CastAcceptServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	if err = s.LevelUp.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcJunkServerPacket :: Clearing all boss children.
 type NpcJunkServerPacket struct {
+	byteSize int
+
 	NpcId int
 }
 
@@ -10725,6 +12678,11 @@ func (s NpcJunkServerPacket) Family() net.PacketFamily {
 
 func (s NpcJunkServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Junk
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcJunkServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcJunkServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10742,14 +12700,18 @@ func (s *NpcJunkServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcId : field : short
 	s.NpcId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcPlayerServerPacket :: Main NPC update message.
 type NpcPlayerServerPacket struct {
+	byteSize int
+
 	Positions []NpcUpdatePosition
 	Attacks   []NpcUpdateAttack
 	Chats     []NpcUpdateChat
@@ -10763,6 +12725,11 @@ func (s NpcPlayerServerPacket) Family() net.PacketFamily {
 
 func (s NpcPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10814,6 +12781,7 @@ func (s *NpcPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Positions : array : NpcUpdatePosition
 	PositionsRemaining := reader.Remaining()
@@ -10861,12 +12829,15 @@ func (s *NpcPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		*s.Tp = reader.GetShort()
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcDialogServerPacket :: NPC chat message.
 type NpcDialogServerPacket struct {
+	byteSize int
+
 	NpcIndex int
 	Message  string
 }
@@ -10877,6 +12848,11 @@ func (s NpcDialogServerPacket) Family() net.PacketFamily {
 
 func (s NpcDialogServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Dialog
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcDialogServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcDialogServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10898,6 +12874,7 @@ func (s *NpcDialogServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : short
 	s.NpcIndex = reader.GetShort()
 	// Message : field : string
@@ -10905,11 +12882,15 @@ func (s *NpcDialogServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // QuestReportServerPacket :: NPC chat messages.
 type QuestReportServerPacket struct {
+	byteSize int
+
 	NpcId    int
 	Messages []string
 }
@@ -10920,6 +12901,11 @@ func (s QuestReportServerPacket) Family() net.PacketFamily {
 
 func (s QuestReportServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Report
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *QuestReportServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *QuestReportServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -10948,6 +12934,7 @@ func (s *QuestReportServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// NpcId : field : short
 	s.NpcId = reader.GetShort()
@@ -10967,12 +12954,15 @@ func (s *QuestReportServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // QuestDialogServerPacket :: Quest selection dialog.
 type QuestDialogServerPacket struct {
+	byteSize int
+
 	QuestCount    int
 	BehaviorId    int
 	QuestId       int
@@ -10988,6 +12978,11 @@ func (s QuestDialogServerPacket) Family() net.PacketFamily {
 
 func (s QuestDialogServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Dialog
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *QuestDialogServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *QuestDialogServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11040,6 +13035,7 @@ func (s *QuestDialogServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// QuestCount : length : char
 	s.QuestCount = reader.GetChar()
@@ -11077,12 +13073,15 @@ func (s *QuestDialogServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // QuestListServerPacket :: Quest history / progress reply.
 type QuestListServerPacket struct {
+	byteSize int
+
 	Page        net.QuestPage
 	QuestsCount int
 	PageData    QuestListPageData
@@ -11093,7 +13092,14 @@ type QuestListPageData interface {
 }
 
 type QuestListPageDataProgress struct {
+	byteSize int
+
 	QuestProgressEntries []QuestProgressEntry
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *QuestListPageDataProgress) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *QuestListPageDataProgress) Serialize(writer *data.EoWriter) (err error) {
@@ -11115,6 +13121,7 @@ func (s *QuestListPageDataProgress) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// QuestProgressEntries : array : QuestProgressEntry
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
 		s.QuestProgressEntries = append(s.QuestProgressEntries, QuestProgressEntry{})
@@ -11126,11 +13133,20 @@ func (s *QuestListPageDataProgress) Deserialize(reader *data.EoReader) (err erro
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 type QuestListPageDataHistory struct {
+	byteSize int
+
 	CompletedQuests []string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *QuestListPageDataHistory) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *QuestListPageDataHistory) Serialize(writer *data.EoWriter) (err error) {
@@ -11152,6 +13168,7 @@ func (s *QuestListPageDataHistory) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CompletedQuests : array : string
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
 		s.CompletedQuests = append(s.CompletedQuests, "")
@@ -11164,6 +13181,8 @@ func (s *QuestListPageDataHistory) Deserialize(reader *data.EoReader) (err error
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
@@ -11173,6 +13192,11 @@ func (s QuestListServerPacket) Family() net.PacketFamily {
 
 func (s QuestListServerPacket) Action() net.PacketAction {
 	return net.PacketAction_List
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *QuestListServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *QuestListServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11218,6 +13242,7 @@ func (s *QuestListServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Page : field : QuestPage
 	s.Page = net.QuestPage(reader.GetChar())
@@ -11236,12 +13261,15 @@ func (s *QuestListServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemAcceptServerPacket :: Nearby player leveled up from quest.
 type ItemAcceptServerPacket struct {
+	byteSize int
+
 	PlayerId int
 }
 
@@ -11251,6 +13279,11 @@ func (s ItemAcceptServerPacket) Family() net.PacketFamily {
 
 func (s ItemAcceptServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemAcceptServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11268,14 +13301,17 @@ func (s *ItemAcceptServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ArenaDropServerPacket :: "Arena is blocked" message.
 type ArenaDropServerPacket struct {
+	byteSize int
 }
 
 func (s ArenaDropServerPacket) Family() net.PacketFamily {
@@ -11284,6 +13320,11 @@ func (s ArenaDropServerPacket) Family() net.PacketFamily {
 
 func (s ArenaDropServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Drop
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ArenaDropServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ArenaDropServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11301,16 +13342,20 @@ func (s *ArenaDropServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// N : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ArenaUseServerPacket :: Arena start message.
 type ArenaUseServerPacket struct {
+	byteSize int
+
 	PlayersCount int
 }
 
@@ -11320,6 +13365,11 @@ func (s ArenaUseServerPacket) Family() net.PacketFamily {
 
 func (s ArenaUseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ArenaUseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ArenaUseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11337,14 +13387,18 @@ func (s *ArenaUseServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayersCount : field : char
 	s.PlayersCount = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ArenaSpecServerPacket :: Arena kill message.
 type ArenaSpecServerPacket struct {
+	byteSize int
+
 	PlayerId   int
 	Direction  protocol.Direction
 	KillsCount int
@@ -11358,6 +13412,11 @@ func (s ArenaSpecServerPacket) Family() net.PacketFamily {
 
 func (s ArenaSpecServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Spec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ArenaSpecServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ArenaSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11397,6 +13456,7 @@ func (s *ArenaSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
@@ -11427,12 +13487,15 @@ func (s *ArenaSpecServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ArenaAcceptServerPacket :: Arena win message.
 type ArenaAcceptServerPacket struct {
+	byteSize int
+
 	WinnerName string
 	KillsCount int
 	KillerName string
@@ -11445,6 +13508,11 @@ func (s ArenaAcceptServerPacket) Family() net.PacketFamily {
 
 func (s ArenaAcceptServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Accept
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ArenaAcceptServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ArenaAcceptServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11479,6 +13547,7 @@ func (s *ArenaAcceptServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// WinnerName : field : string
 	if s.WinnerName, err = reader.GetString(); err != nil {
@@ -11507,12 +13576,15 @@ func (s *ArenaAcceptServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MarriageOpenServerPacket :: Response from talking to a law NPC.
 type MarriageOpenServerPacket struct {
+	byteSize int
+
 	SessionId int
 }
 
@@ -11522,6 +13594,11 @@ func (s MarriageOpenServerPacket) Family() net.PacketFamily {
 
 func (s MarriageOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MarriageOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MarriageOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11539,14 +13616,18 @@ func (s *MarriageOpenServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : three
 	s.SessionId = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MarriageReplyServerPacket :: Reply to client Marriage-family packets.
 type MarriageReplyServerPacket struct {
+	byteSize int
+
 	ReplyCode     MarriageReply
 	ReplyCodeData MarriageReplyReplyCodeData
 }
@@ -11556,7 +13637,14 @@ type MarriageReplyReplyCodeData interface {
 }
 
 type MarriageReplyReplyCodeDataSuccess struct {
+	byteSize int
+
 	GoldAmount int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MarriageReplyReplyCodeDataSuccess) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MarriageReplyReplyCodeDataSuccess) Serialize(writer *data.EoWriter) (err error) {
@@ -11574,8 +13662,10 @@ func (s *MarriageReplyReplyCodeDataSuccess) Deserialize(reader *data.EoReader) (
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// GoldAmount : field : int
 	s.GoldAmount = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -11586,6 +13676,11 @@ func (s MarriageReplyServerPacket) Family() net.PacketFamily {
 
 func (s MarriageReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MarriageReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MarriageReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11615,6 +13710,7 @@ func (s *MarriageReplyServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ReplyCode : field : MarriageReply
 	s.ReplyCode = MarriageReply(reader.GetShort())
 	switch s.ReplyCode {
@@ -11624,12 +13720,15 @@ func (s *MarriageReplyServerPacket) Deserialize(reader *data.EoReader) (err erro
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PriestOpenServerPacket :: Response from talking to a priest NPC.
 type PriestOpenServerPacket struct {
+	byteSize int
+
 	SessionId int
 }
 
@@ -11639,6 +13738,11 @@ func (s PriestOpenServerPacket) Family() net.PacketFamily {
 
 func (s PriestOpenServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Open
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PriestOpenServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PriestOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11656,14 +13760,18 @@ func (s *PriestOpenServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : int
 	s.SessionId = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PriestReplyServerPacket :: Reply to client Priest-family packets.
 type PriestReplyServerPacket struct {
+	byteSize int
+
 	ReplyCode PriestReply
 }
 
@@ -11673,6 +13781,11 @@ func (s PriestReplyServerPacket) Family() net.PacketFamily {
 
 func (s PriestReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PriestReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PriestReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11690,14 +13803,18 @@ func (s *PriestReplyServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ReplyCode : field : PriestReply
 	s.ReplyCode = PriestReply(reader.GetShort())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PriestRequestServerPacket :: Wedding request.
 type PriestRequestServerPacket struct {
+	byteSize int
+
 	SessionId   int
 	PartnerName string
 }
@@ -11708,6 +13825,11 @@ func (s PriestRequestServerPacket) Family() net.PacketFamily {
 
 func (s PriestRequestServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Request
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PriestRequestServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PriestRequestServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11729,6 +13851,7 @@ func (s *PriestRequestServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
 	// PartnerName : field : string
@@ -11736,11 +13859,15 @@ func (s *PriestRequestServerPacket) Deserialize(reader *data.EoReader) (err erro
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // RecoverPlayerServerPacket :: HP/TP update.
 type RecoverPlayerServerPacket struct {
+	byteSize int
+
 	Hp int
 	Tp int
 }
@@ -11751,6 +13878,11 @@ func (s RecoverPlayerServerPacket) Family() net.PacketFamily {
 
 func (s RecoverPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *RecoverPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *RecoverPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11772,16 +13904,20 @@ func (s *RecoverPlayerServerPacket) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Hp : field : short
 	s.Hp = reader.GetShort()
 	// Tp : field : short
 	s.Tp = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // RecoverAgreeServerPacket :: Nearby player gained HP.
 type RecoverAgreeServerPacket struct {
+	byteSize int
+
 	PlayerId     int
 	HealHp       int
 	HpPercentage int
@@ -11793,6 +13929,11 @@ func (s RecoverAgreeServerPacket) Family() net.PacketFamily {
 
 func (s RecoverAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *RecoverAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *RecoverAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11818,18 +13959,22 @@ func (s *RecoverAgreeServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// HealHp : field : int
 	s.HealHp = reader.GetInt()
 	// HpPercentage : field : char
 	s.HpPercentage = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // RecoverListServerPacket :: Stats update.
 type RecoverListServerPacket struct {
+	byteSize int
+
 	ClassId int
 	Stats   CharacterStatsUpdate
 }
@@ -11840,6 +13985,11 @@ func (s RecoverListServerPacket) Family() net.PacketFamily {
 
 func (s RecoverListServerPacket) Action() net.PacketAction {
 	return net.PacketAction_List
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *RecoverListServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *RecoverListServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11861,18 +14011,22 @@ func (s *RecoverListServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ClassId : field : short
 	s.ClassId = reader.GetShort()
 	// Stats : field : CharacterStatsUpdate
 	if err = s.Stats.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // RecoverReplyServerPacket :: Karma/experience update.
 type RecoverReplyServerPacket struct {
+	byteSize int
+
 	Experience  int
 	Karma       int
 	LevelUp     *int //  A value greater than 0 is "new level" and indicates the player leveled up. The official client reads this if the packet is larger than 6 bytes.
@@ -11886,6 +14040,11 @@ func (s RecoverReplyServerPacket) Family() net.PacketFamily {
 
 func (s RecoverReplyServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *RecoverReplyServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *RecoverReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11925,6 +14084,7 @@ func (s *RecoverReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Experience : field : int
 	s.Experience = reader.GetInt()
 	// Karma : field : short
@@ -11944,12 +14104,15 @@ func (s *RecoverReplyServerPacket) Deserialize(reader *data.EoReader) (err error
 		s.SkillPoints = new(int)
 		*s.SkillPoints = reader.GetShort()
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // RecoverTargetGroupServerPacket :: Updated stats when levelling up from party experience.
 type RecoverTargetGroupServerPacket struct {
+	byteSize int
+
 	StatPoints  int
 	SkillPoints int
 	MaxHp       int
@@ -11963,6 +14126,11 @@ func (s RecoverTargetGroupServerPacket) Family() net.PacketFamily {
 
 func (s RecoverTargetGroupServerPacket) Action() net.PacketAction {
 	return net.PacketAction_TargetGroup
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *RecoverTargetGroupServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *RecoverTargetGroupServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -11996,6 +14164,7 @@ func (s *RecoverTargetGroupServerPacket) Deserialize(reader *data.EoReader) (err
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// StatPoints : field : short
 	s.StatPoints = reader.GetShort()
 	// SkillPoints : field : short
@@ -12006,12 +14175,15 @@ func (s *RecoverTargetGroupServerPacket) Deserialize(reader *data.EoReader) (err
 	s.MaxTp = reader.GetShort()
 	// MaxSp : field : short
 	s.MaxSp = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EffectUseServerPacket :: Map effect.
 type EffectUseServerPacket struct {
+	byteSize int
+
 	Effect     MapEffect
 	EffectData EffectUseEffectData
 }
@@ -12021,7 +14193,14 @@ type EffectUseEffectData interface {
 }
 
 type EffectUseEffectDataQuake struct {
+	byteSize int
+
 	QuakeStrength int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EffectUseEffectDataQuake) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EffectUseEffectDataQuake) Serialize(writer *data.EoWriter) (err error) {
@@ -12039,8 +14218,10 @@ func (s *EffectUseEffectDataQuake) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// QuakeStrength : field : char
 	s.QuakeStrength = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -12051,6 +14232,11 @@ func (s EffectUseServerPacket) Family() net.PacketFamily {
 
 func (s EffectUseServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Use
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EffectUseServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EffectUseServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -12080,6 +14266,7 @@ func (s *EffectUseServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Effect : field : MapEffect
 	s.Effect = MapEffect(reader.GetChar())
 	switch s.Effect {
@@ -12089,12 +14276,15 @@ func (s *EffectUseServerPacket) Deserialize(reader *data.EoReader) (err error) {
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EffectAgreeServerPacket :: Effects playing on nearby tiles.
 type EffectAgreeServerPacket struct {
+	byteSize int
+
 	Effects []TileEffect
 }
 
@@ -12104,6 +14294,11 @@ func (s EffectAgreeServerPacket) Family() net.PacketFamily {
 
 func (s EffectAgreeServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Agree
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EffectAgreeServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EffectAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -12124,6 +14319,7 @@ func (s *EffectAgreeServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Effects : array : TileEffect
 	for ndx := 0; reader.Remaining() > 0; ndx++ {
 		s.Effects = append(s.Effects, TileEffect{})
@@ -12132,11 +14328,15 @@ func (s *EffectAgreeServerPacket) Deserialize(reader *data.EoReader) (err error)
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // EffectTargetOtherServerPacket :: Map drain damage.
 type EffectTargetOtherServerPacket struct {
+	byteSize int
+
 	Damage int
 	Hp     int
 	MaxHp  int
@@ -12149,6 +14349,11 @@ func (s EffectTargetOtherServerPacket) Family() net.PacketFamily {
 
 func (s EffectTargetOtherServerPacket) Action() net.PacketAction {
 	return net.PacketAction_TargetOther
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EffectTargetOtherServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EffectTargetOtherServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -12181,6 +14386,7 @@ func (s *EffectTargetOtherServerPacket) Deserialize(reader *data.EoReader) (err 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Damage : field : short
 	s.Damage = reader.GetShort()
 	// Hp : field : short
@@ -12195,11 +14401,14 @@ func (s *EffectTargetOtherServerPacket) Deserialize(reader *data.EoReader) (err 
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // EffectReportServerPacket :: Map spike timer.
 type EffectReportServerPacket struct {
+	byteSize int
 }
 
 func (s EffectReportServerPacket) Family() net.PacketFamily {
@@ -12208,6 +14417,11 @@ func (s EffectReportServerPacket) Family() net.PacketFamily {
 
 func (s EffectReportServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Report
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EffectReportServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EffectReportServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -12225,16 +14439,20 @@ func (s *EffectReportServerPacket) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// S : dummy : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EffectSpecServerPacket :: Taking spike or tp drain damage.
 type EffectSpecServerPacket struct {
+	byteSize int
+
 	MapDamageType     MapDamageType
 	MapDamageTypeData EffectSpecMapDamageTypeData
 }
@@ -12244,9 +14462,16 @@ type EffectSpecMapDamageTypeData interface {
 }
 
 type EffectSpecMapDamageTypeDataTpDrain struct {
+	byteSize int
+
 	TpDamage int
 	Tp       int
 	MaxTp    int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EffectSpecMapDamageTypeDataTpDrain) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EffectSpecMapDamageTypeDataTpDrain) Serialize(writer *data.EoWriter) (err error) {
@@ -12272,20 +14497,29 @@ func (s *EffectSpecMapDamageTypeDataTpDrain) Deserialize(reader *data.EoReader) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// TpDamage : field : short
 	s.TpDamage = reader.GetShort()
 	// Tp : field : short
 	s.Tp = reader.GetShort()
 	// MaxTp : field : short
 	s.MaxTp = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type EffectSpecMapDamageTypeDataSpikes struct {
+	byteSize int
+
 	HpDamage int
 	Hp       int
 	MaxHp    int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EffectSpecMapDamageTypeDataSpikes) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EffectSpecMapDamageTypeDataSpikes) Serialize(writer *data.EoWriter) (err error) {
@@ -12311,12 +14545,14 @@ func (s *EffectSpecMapDamageTypeDataSpikes) Deserialize(reader *data.EoReader) (
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// HpDamage : field : short
 	s.HpDamage = reader.GetShort()
 	// Hp : field : short
 	s.Hp = reader.GetShort()
 	// MaxHp : field : short
 	s.MaxHp = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
@@ -12327,6 +14563,11 @@ func (s EffectSpecServerPacket) Family() net.PacketFamily {
 
 func (s EffectSpecServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Spec
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EffectSpecServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EffectSpecServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -12366,6 +14607,7 @@ func (s *EffectSpecServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MapDamageType : field : MapDamageType
 	s.MapDamageType = MapDamageType(reader.GetChar())
 	switch s.MapDamageType {
@@ -12380,12 +14622,15 @@ func (s *EffectSpecServerPacket) Deserialize(reader *data.EoReader) (err error) 
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EffectAdminServerPacket :: Nearby character taking spike damage.
 type EffectAdminServerPacket struct {
+	byteSize int
+
 	PlayerId     int
 	HpPercentage int
 	Died         bool
@@ -12398,6 +14643,11 @@ func (s EffectAdminServerPacket) Family() net.PacketFamily {
 
 func (s EffectAdminServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Admin
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EffectAdminServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EffectAdminServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -12433,6 +14683,7 @@ func (s *EffectAdminServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// HpPercentage : field : char
@@ -12445,12 +14696,15 @@ func (s *EffectAdminServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 	// Damage : field : three
 	s.Damage = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MusicPlayerServerPacket :: Sound effect.
 type MusicPlayerServerPacket struct {
+	byteSize int
+
 	SoundId int
 }
 
@@ -12460,6 +14714,11 @@ func (s MusicPlayerServerPacket) Family() net.PacketFamily {
 
 func (s MusicPlayerServerPacket) Action() net.PacketAction {
 	return net.PacketAction_Player
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MusicPlayerServerPacket) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MusicPlayerServerPacket) Serialize(writer *data.EoWriter) (err error) {
@@ -12477,8 +14736,10 @@ func (s *MusicPlayerServerPacket) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SoundId : field : char
 	s.SoundId = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }

--- a/pkg/eolib/protocol/net/server/packets_generated.go
+++ b/pkg/eolib/protocol/net/server/packets_generated.go
@@ -1837,8 +1837,6 @@ func (s *CharacterReplyReplyCodeDataNotApproved) Deserialize(reader *data.EoRead
 type CharacterReplyReplyCodeDataOk struct {
 	byteSize int
 
-	CharactersCount int
-
 	Characters []CharacterSelectionListEntry
 }
 
@@ -1852,7 +1850,7 @@ func (s *CharacterReplyReplyCodeDataOk) Serialize(writer *data.EoWriter) (err er
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// CharactersCount : length : char
-	if err = writer.AddChar(s.CharactersCount); err != nil {
+	if err = writer.AddChar(len(s.Characters)); err != nil {
 		return
 	}
 	// 0 : field : char
@@ -1861,7 +1859,7 @@ func (s *CharacterReplyReplyCodeDataOk) Serialize(writer *data.EoWriter) (err er
 	}
 	writer.AddByte(255)
 	// Characters : array : CharacterSelectionListEntry
-	for ndx := 0; ndx < s.CharactersCount; ndx++ {
+	for ndx := 0; ndx < len(s.Characters); ndx++ {
 		if err = s.Characters[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -1877,14 +1875,14 @@ func (s *CharacterReplyReplyCodeDataOk) Deserialize(reader *data.EoReader) (err 
 
 	readerStartPosition := reader.Position()
 	// CharactersCount : length : char
-	s.CharactersCount = reader.GetChar()
+	charactersCount := reader.GetChar()
 	// 0 : field : char
 	reader.GetChar()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
 	// Characters : array : CharacterSelectionListEntry
-	for ndx := 0; ndx < s.CharactersCount; ndx++ {
+	for ndx := 0; ndx < charactersCount; ndx++ {
 		s.Characters = append(s.Characters, CharacterSelectionListEntry{})
 		if err = s.Characters[ndx].Deserialize(reader); err != nil {
 			return
@@ -1902,8 +1900,7 @@ func (s *CharacterReplyReplyCodeDataOk) Deserialize(reader *data.EoReader) (err 
 type CharacterReplyReplyCodeDataDeleted struct {
 	byteSize int
 
-	CharactersCount int
-	Characters      []CharacterSelectionListEntry
+	Characters []CharacterSelectionListEntry
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -1916,12 +1913,12 @@ func (s *CharacterReplyReplyCodeDataDeleted) Serialize(writer *data.EoWriter) (e
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// CharactersCount : length : char
-	if err = writer.AddChar(s.CharactersCount); err != nil {
+	if err = writer.AddChar(len(s.Characters)); err != nil {
 		return
 	}
 	writer.AddByte(255)
 	// Characters : array : CharacterSelectionListEntry
-	for ndx := 0; ndx < s.CharactersCount; ndx++ {
+	for ndx := 0; ndx < len(s.Characters); ndx++ {
 		if err = s.Characters[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -1937,12 +1934,12 @@ func (s *CharacterReplyReplyCodeDataDeleted) Deserialize(reader *data.EoReader) 
 
 	readerStartPosition := reader.Position()
 	// CharactersCount : length : char
-	s.CharactersCount = reader.GetChar()
+	charactersCount := reader.GetChar()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
 	// Characters : array : CharacterSelectionListEntry
-	for ndx := 0; ndx < s.CharactersCount; ndx++ {
+	for ndx := 0; ndx < charactersCount; ndx++ {
 		s.Characters = append(s.Characters, CharacterSelectionListEntry{})
 		if err = s.Characters[ndx].Deserialize(reader); err != nil {
 			return
@@ -2274,8 +2271,6 @@ func (s *LoginReplyReplyCodeDataWrongUserPassword) Deserialize(reader *data.EoRe
 type LoginReplyReplyCodeDataOk struct {
 	byteSize int
 
-	CharactersCount int
-
 	Characters []CharacterSelectionListEntry
 }
 
@@ -2289,7 +2284,7 @@ func (s *LoginReplyReplyCodeDataOk) Serialize(writer *data.EoWriter) (err error)
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// CharactersCount : length : char
-	if err = writer.AddChar(s.CharactersCount); err != nil {
+	if err = writer.AddChar(len(s.Characters)); err != nil {
 		return
 	}
 	// 0 : field : char
@@ -2298,7 +2293,7 @@ func (s *LoginReplyReplyCodeDataOk) Serialize(writer *data.EoWriter) (err error)
 	}
 	writer.AddByte(255)
 	// Characters : array : CharacterSelectionListEntry
-	for ndx := 0; ndx < s.CharactersCount; ndx++ {
+	for ndx := 0; ndx < len(s.Characters); ndx++ {
 		if err = s.Characters[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -2314,14 +2309,14 @@ func (s *LoginReplyReplyCodeDataOk) Deserialize(reader *data.EoReader) (err erro
 
 	readerStartPosition := reader.Position()
 	// CharactersCount : length : char
-	s.CharactersCount = reader.GetChar()
+	charactersCount := reader.GetChar()
 	// 0 : field : char
 	reader.GetChar()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
 	// Characters : array : CharacterSelectionListEntry
-	for ndx := 0; ndx < s.CharactersCount; ndx++ {
+	for ndx := 0; ndx < charactersCount; ndx++ {
 		s.Characters = append(s.Characters, CharacterSelectionListEntry{})
 		if err = s.Characters[ndx].Deserialize(reader); err != nil {
 			return
@@ -5399,8 +5394,7 @@ func (s *RangeReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 type NpcAgreeServerPacket struct {
 	byteSize int
 
-	NpcsCount int
-	Npcs      []NpcMapInfo
+	Npcs []NpcMapInfo
 }
 
 func (s NpcAgreeServerPacket) Family() net.PacketFamily {
@@ -5421,11 +5415,11 @@ func (s *NpcAgreeServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// NpcsCount : length : char
-	if err = writer.AddChar(s.NpcsCount); err != nil {
+	if err = writer.AddChar(len(s.Npcs)); err != nil {
 		return
 	}
 	// Npcs : array : NpcMapInfo
-	for ndx := 0; ndx < s.NpcsCount; ndx++ {
+	for ndx := 0; ndx < len(s.Npcs); ndx++ {
 		if err = s.Npcs[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -5440,9 +5434,9 @@ func (s *NpcAgreeServerPacket) Deserialize(reader *data.EoReader) (err error) {
 
 	readerStartPosition := reader.Position()
 	// NpcsCount : length : char
-	s.NpcsCount = reader.GetChar()
+	npcsCount := reader.GetChar()
 	// Npcs : array : NpcMapInfo
-	for ndx := 0; ndx < s.NpcsCount; ndx++ {
+	for ndx := 0; ndx < npcsCount; ndx++ {
 		s.Npcs = append(s.Npcs, NpcMapInfo{})
 		if err = s.Npcs[ndx].Deserialize(reader); err != nil {
 			return
@@ -8106,9 +8100,8 @@ func (s *BoardPlayerServerPacket) Deserialize(reader *data.EoReader) (err error)
 type BoardOpenServerPacket struct {
 	byteSize int
 
-	BoardId    int
-	PostsCount int
-	Posts      []BoardPostListing
+	BoardId int
+	Posts   []BoardPostListing
 }
 
 func (s BoardOpenServerPacket) Family() net.PacketFamily {
@@ -8134,11 +8127,11 @@ func (s *BoardOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// PostsCount : length : char
-	if err = writer.AddChar(s.PostsCount); err != nil {
+	if err = writer.AddChar(len(s.Posts)); err != nil {
 		return
 	}
 	// Posts : array : BoardPostListing
-	for ndx := 0; ndx < s.PostsCount; ndx++ {
+	for ndx := 0; ndx < len(s.Posts); ndx++ {
 		if err = s.Posts[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -8158,9 +8151,9 @@ func (s *BoardOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	// BoardId : field : char
 	s.BoardId = reader.GetChar()
 	// PostsCount : length : char
-	s.PostsCount = reader.GetChar()
+	postsCount := reader.GetChar()
 	// Posts : array : BoardPostListing
-	for ndx := 0; ndx < s.PostsCount; ndx++ {
+	for ndx := 0; ndx < postsCount; ndx++ {
 		s.Posts = append(s.Posts, BoardPostListing{})
 		if err = s.Posts[ndx].Deserialize(reader); err != nil {
 			return
@@ -10948,8 +10941,7 @@ func (s *GuildOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 type GuildTellServerPacket struct {
 	byteSize int
 
-	MembersCount int
-	Members      []GuildMember
+	Members []GuildMember
 }
 
 func (s GuildTellServerPacket) Family() net.PacketFamily {
@@ -10971,12 +10963,12 @@ func (s *GuildTellServerPacket) Serialize(writer *data.EoWriter) (err error) {
 
 	writer.SanitizeStrings = true
 	// MembersCount : length : short
-	if err = writer.AddShort(s.MembersCount); err != nil {
+	if err = writer.AddShort(len(s.Members)); err != nil {
 		return
 	}
 	writer.AddByte(255)
 	// Members : array : GuildMember
-	for ndx := 0; ndx < s.MembersCount; ndx++ {
+	for ndx := 0; ndx < len(s.Members); ndx++ {
 		if err = s.Members[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -10994,12 +10986,12 @@ func (s *GuildTellServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// MembersCount : length : short
-	s.MembersCount = reader.GetShort()
+	membersCount := reader.GetShort()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
 	// Members : array : GuildMember
-	for ndx := 0; ndx < s.MembersCount; ndx++ {
+	for ndx := 0; ndx < membersCount; ndx++ {
 		s.Members = append(s.Members, GuildMember{})
 		if err = s.Members[ndx].Deserialize(reader); err != nil {
 			return
@@ -11025,7 +11017,6 @@ type GuildReportServerPacket struct {
 	Description string
 	Wealth      string
 	Ranks       []string
-	StaffCount  int
 	Staff       []GuildStaff
 }
 
@@ -11086,12 +11077,12 @@ func (s *GuildReportServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	}
 
 	// StaffCount : length : short
-	if err = writer.AddShort(s.StaffCount); err != nil {
+	if err = writer.AddShort(len(s.Staff)); err != nil {
 		return
 	}
 	writer.AddByte(255)
 	// Staff : array : GuildStaff
-	for ndx := 0; ndx < s.StaffCount; ndx++ {
+	for ndx := 0; ndx < len(s.Staff); ndx++ {
 		if err = s.Staff[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -11161,12 +11152,12 @@ func (s *GuildReportServerPacket) Deserialize(reader *data.EoReader) (err error)
 	}
 
 	// StaffCount : length : short
-	s.StaffCount = reader.GetShort()
+	staffCount := reader.GetShort()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
 	// Staff : array : GuildStaff
-	for ndx := 0; ndx < s.StaffCount; ndx++ {
+	for ndx := 0; ndx < staffCount; ndx++ {
 		s.Staff = append(s.Staff, GuildStaff{})
 		if err = s.Staff[ndx].Deserialize(reader); err != nil {
 			return
@@ -13027,7 +13018,6 @@ func (s *QuestReportServerPacket) Deserialize(reader *data.EoReader) (err error)
 type QuestDialogServerPacket struct {
 	byteSize int
 
-	QuestCount    int
 	BehaviorId    int
 	QuestId       int
 	SessionId     int
@@ -13055,7 +13045,7 @@ func (s *QuestDialogServerPacket) Serialize(writer *data.EoWriter) (err error) {
 
 	writer.SanitizeStrings = true
 	// QuestCount : length : char
-	if err = writer.AddChar(s.QuestCount); err != nil {
+	if err = writer.AddChar(len(s.QuestEntries)); err != nil {
 		return
 	}
 	// BehaviorId : field : short
@@ -13076,7 +13066,7 @@ func (s *QuestDialogServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	}
 	writer.AddByte(255)
 	// QuestEntries : array : DialogQuestEntry
-	for ndx := 0; ndx < s.QuestCount; ndx++ {
+	for ndx := 0; ndx < len(s.QuestEntries); ndx++ {
 		if err = s.QuestEntries[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -13102,7 +13092,7 @@ func (s *QuestDialogServerPacket) Deserialize(reader *data.EoReader) (err error)
 	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// QuestCount : length : char
-	s.QuestCount = reader.GetChar()
+	questCount := reader.GetChar()
 	// BehaviorId : field : short
 	s.BehaviorId = reader.GetShort()
 	// QuestId : field : short
@@ -13115,7 +13105,7 @@ func (s *QuestDialogServerPacket) Deserialize(reader *data.EoReader) (err error)
 		return
 	}
 	// QuestEntries : array : DialogQuestEntry
-	for ndx := 0; ndx < s.QuestCount; ndx++ {
+	for ndx := 0; ndx < questCount; ndx++ {
 		s.QuestEntries = append(s.QuestEntries, DialogQuestEntry{})
 		if err = s.QuestEntries[ndx].Deserialize(reader); err != nil {
 			return

--- a/pkg/eolib/protocol/net/server/packets_generated.go
+++ b/pkg/eolib/protocol/net/server/packets_generated.go
@@ -2640,6 +2640,11 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Serialize(writer *data.EoWr
 	}
 	// MapRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.MapRid) != 2 {
+			err = fmt.Errorf("expected MapRid with length 2, got %d", len(s.MapRid))
+			return
+		}
+
 		if err = writer.AddShort(s.MapRid[ndx]); err != nil {
 			return
 		}
@@ -2651,6 +2656,11 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Serialize(writer *data.EoWr
 	}
 	// EifRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.EifRid) != 2 {
+			err = fmt.Errorf("expected EifRid with length 2, got %d", len(s.EifRid))
+			return
+		}
+
 		if err = writer.AddShort(s.EifRid[ndx]); err != nil {
 			return
 		}
@@ -2662,6 +2672,11 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Serialize(writer *data.EoWr
 	}
 	// EnfRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.EnfRid) != 2 {
+			err = fmt.Errorf("expected EnfRid with length 2, got %d", len(s.EnfRid))
+			return
+		}
+
 		if err = writer.AddShort(s.EnfRid[ndx]); err != nil {
 			return
 		}
@@ -2673,6 +2688,11 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Serialize(writer *data.EoWr
 	}
 	// EsfRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.EsfRid) != 2 {
+			err = fmt.Errorf("expected EsfRid with length 2, got %d", len(s.EsfRid))
+			return
+		}
+
 		if err = writer.AddShort(s.EsfRid[ndx]); err != nil {
 			return
 		}
@@ -2684,6 +2704,11 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Serialize(writer *data.EoWr
 	}
 	// EcfRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.EcfRid) != 2 {
+			err = fmt.Errorf("expected EcfRid with length 2, got %d", len(s.EcfRid))
+			return
+		}
+
 		if err = writer.AddShort(s.EcfRid[ndx]); err != nil {
 			return
 		}
@@ -2718,6 +2743,10 @@ func (s *WelcomeReplyWelcomeCodeDataSelectCharacter) Serialize(writer *data.EoWr
 		return
 	}
 	// GuildTag : field : string
+	if len(s.GuildTag) != 3 {
+		err = fmt.Errorf("expected GuildTag with length 3, got %d", len(s.GuildTag))
+		return
+	}
 	if err = writer.AddFixedString(s.GuildTag, 3); err != nil {
 		return
 	}
@@ -2905,6 +2934,11 @@ func (s *WelcomeReplyWelcomeCodeDataEnterGame) Serialize(writer *data.EoWriter) 
 	writer.AddByte(255)
 	// News : array : string
 	for ndx := 0; ndx < 9; ndx++ {
+		if len(s.News) != 9 {
+			err = fmt.Errorf("expected News with length 9, got %d", len(s.News))
+			return
+		}
+
 		if err = writer.AddString(s.News[ndx]); err != nil {
 			return
 		}
@@ -4301,6 +4335,11 @@ func (s *MessageAcceptServerPacket) Serialize(writer *data.EoWriter) (err error)
 	writer.SanitizeStrings = true
 	// Messages : array : string
 	for ndx := 0; ndx < 4; ndx++ {
+		if len(s.Messages) != 4 {
+			err = fmt.Errorf("expected Messages with length 4, got %d", len(s.Messages))
+			return
+		}
+
 		if err = writer.AddString(s.Messages[ndx]); err != nil {
 			return
 		}
@@ -6279,6 +6318,11 @@ func (s *CitizenOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	writer.AddByte(255)
 	// Questions : array : string
 	for ndx := 0; ndx < 3; ndx++ {
+		if len(s.Questions) != 3 {
+			err = fmt.Errorf("expected Questions with length 3, got %d", len(s.Questions))
+			return
+		}
+
 		if ndx > 0 {
 			writer.AddByte(255)
 		}
@@ -6449,6 +6493,11 @@ func (s *ShopCreateServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Ingredients : array : Item
 	for ndx := 0; ndx < 4; ndx++ {
+		if len(s.Ingredients) != 4 {
+			err = fmt.Errorf("expected Ingredients with length 4, got %d", len(s.Ingredients))
+			return
+		}
+
 		if err = s.Ingredients[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -8446,6 +8495,11 @@ func (s *WarpRequestWarpTypeDataMapSwitch) Serialize(writer *data.EoWriter) (err
 
 	// MapRid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.MapRid) != 2 {
+			err = fmt.Errorf("expected MapRid with length 2, got %d", len(s.MapRid))
+			return
+		}
+
 		if err = writer.AddShort(s.MapRid[ndx]); err != nil {
 			return
 		}
@@ -10722,6 +10776,11 @@ func (s *GuildRankServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	writer.SanitizeStrings = true
 	// Ranks : array : string
 	for ndx := 0; ndx < 9; ndx++ {
+		if len(s.Ranks) != 9 {
+			err = fmt.Errorf("expected Ranks with length 9, got %d", len(s.Ranks))
+			return
+		}
+
 		if err = writer.AddString(s.Ranks[ndx]); err != nil {
 			return
 		}
@@ -11015,6 +11074,11 @@ func (s *GuildReportServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	writer.AddByte(255)
 	// Ranks : array : string
 	for ndx := 0; ndx < 9; ndx++ {
+		if len(s.Ranks) != 9 {
+			err = fmt.Errorf("expected Ranks with length 9, got %d", len(s.Ranks))
+			return
+		}
+
 		if err = writer.AddString(s.Ranks[ndx]); err != nil {
 			return
 		}

--- a/pkg/eolib/protocol/net/server/packets_generated.go
+++ b/pkg/eolib/protocol/net/server/packets_generated.go
@@ -2516,7 +2516,8 @@ func (s *WelcomeReplyWelcomeCodeDataEnterGame) Deserialize(reader *data.EoReader
 		return
 	}
 	// Items : array : Item
-	for ndx := 0; ndx < reader.Remaining()/6; ndx++ {
+	ItemsRemaining := reader.Remaining()
+	for ndx := 0; ndx < ItemsRemaining/6; ndx++ {
 		s.Items = append(s.Items, net.Item{})
 		if err = s.Items[ndx].Deserialize(reader); err != nil {
 			return
@@ -2527,7 +2528,8 @@ func (s *WelcomeReplyWelcomeCodeDataEnterGame) Deserialize(reader *data.EoReader
 		return
 	}
 	// Spells : array : Spell
-	for ndx := 0; ndx < reader.Remaining()/4; ndx++ {
+	SpellsRemaining := reader.Remaining()
+	for ndx := 0; ndx < SpellsRemaining/4; ndx++ {
 		s.Spells = append(s.Spells, net.Spell{})
 		if err = s.Spells[ndx].Deserialize(reader); err != nil {
 			return
@@ -2947,7 +2949,8 @@ func (s *AdminInteractListServerPacket) Deserialize(reader *data.EoReader) (err 
 		return
 	}
 	// Inventory : array : Item
-	for ndx := 0; ndx < reader.Remaining()/6; ndx++ {
+	InventoryRemaining := reader.Remaining()
+	for ndx := 0; ndx < InventoryRemaining/6; ndx++ {
 		s.Inventory = append(s.Inventory, net.Item{})
 		if err = s.Inventory[ndx].Deserialize(reader); err != nil {
 			return
@@ -2958,7 +2961,8 @@ func (s *AdminInteractListServerPacket) Deserialize(reader *data.EoReader) (err 
 		return
 	}
 	// Bank : array : ThreeItem
-	for ndx := 0; ndx < reader.Remaining()/5; ndx++ {
+	BankRemaining := reader.Remaining()
+	for ndx := 0; ndx < BankRemaining/5; ndx++ {
 		s.Bank = append(s.Bank, net.ThreeItem{})
 		if err = s.Bank[ndx].Deserialize(reader); err != nil {
 			return
@@ -4693,7 +4697,8 @@ func (s *WalkReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 
 	reader.SetIsChunked(true)
 	// PlayerIds : array : short
-	for ndx := 0; ndx < reader.Remaining()/2; ndx++ {
+	PlayerIdsRemaining := reader.Remaining()
+	for ndx := 0; ndx < PlayerIdsRemaining/2; ndx++ {
 		s.PlayerIds = append(s.PlayerIds, 0)
 		s.PlayerIds[ndx] = reader.GetShort()
 	}
@@ -4711,7 +4716,8 @@ func (s *WalkReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// Items : array : ItemMapInfo
-	for ndx := 0; ndx < reader.Remaining()/9; ndx++ {
+	ItemsRemaining := reader.Remaining()
+	for ndx := 0; ndx < ItemsRemaining/9; ndx++ {
 		s.Items = append(s.Items, ItemMapInfo{})
 		if err = s.Items[ndx].Deserialize(reader); err != nil {
 			return
@@ -5651,7 +5657,8 @@ func (s *ShopOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// TradeItems : array : ShopTradeItem
-	for ndx := 0; ndx < reader.Remaining()/9; ndx++ {
+	TradeItemsRemaining := reader.Remaining()
+	for ndx := 0; ndx < TradeItemsRemaining/9; ndx++ {
 		s.TradeItems = append(s.TradeItems, ShopTradeItem{})
 		if err = s.TradeItems[ndx].Deserialize(reader); err != nil {
 			return
@@ -5662,7 +5669,8 @@ func (s *ShopOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// CraftItems : array : ShopCraftItem
-	for ndx := 0; ndx < reader.Remaining()/14; ndx++ {
+	CraftItemsRemaining := reader.Remaining()
+	for ndx := 0; ndx < CraftItemsRemaining/14; ndx++ {
 		s.CraftItems = append(s.CraftItems, ShopCraftItem{})
 		if err = s.CraftItems[ndx].Deserialize(reader); err != nil {
 			return
@@ -5733,7 +5741,8 @@ func (s *StatSkillOpenServerPacket) Deserialize(reader *data.EoReader) (err erro
 		return
 	}
 	// Skills : array : SkillLearn
-	for ndx := 0; ndx < reader.Remaining()/28; ndx++ {
+	SkillsRemaining := reader.Remaining()
+	for ndx := 0; ndx < SkillsRemaining/28; ndx++ {
 		s.Skills = append(s.Skills, SkillLearn{})
 		if err = s.Skills[ndx].Deserialize(reader); err != nil {
 			return
@@ -10807,7 +10816,8 @@ func (s *NpcPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) {
 
 	reader.SetIsChunked(true)
 	// Positions : array : NpcUpdatePosition
-	for ndx := 0; ndx < reader.Remaining()/4; ndx++ {
+	PositionsRemaining := reader.Remaining()
+	for ndx := 0; ndx < PositionsRemaining/4; ndx++ {
 		s.Positions = append(s.Positions, NpcUpdatePosition{})
 		if err = s.Positions[ndx].Deserialize(reader); err != nil {
 			return
@@ -10818,7 +10828,8 @@ func (s *NpcPlayerServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// Attacks : array : NpcUpdateAttack
-	for ndx := 0; ndx < reader.Remaining()/9; ndx++ {
+	AttacksRemaining := reader.Remaining()
+	for ndx := 0; ndx < AttacksRemaining/9; ndx++ {
 		s.Attacks = append(s.Attacks, NpcUpdateAttack{})
 		if err = s.Attacks[ndx].Deserialize(reader); err != nil {
 			return

--- a/pkg/eolib/protocol/net/server/structs_generated.go
+++ b/pkg/eolib/protocol/net/server/structs_generated.go
@@ -329,6 +329,11 @@ func (s *EquipmentWelcome) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Ring : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Ring) != 2 {
+			err = fmt.Errorf("expected Ring with length 2, got %d", len(s.Ring))
+			return
+		}
+
 		if err = writer.AddShort(s.Ring[ndx]); err != nil {
 			return
 		}
@@ -336,6 +341,11 @@ func (s *EquipmentWelcome) Serialize(writer *data.EoWriter) (err error) {
 
 	// Armlet : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Armlet) != 2 {
+			err = fmt.Errorf("expected Armlet with length 2, got %d", len(s.Armlet))
+			return
+		}
+
 		if err = writer.AddShort(s.Armlet[ndx]); err != nil {
 			return
 		}
@@ -343,6 +353,11 @@ func (s *EquipmentWelcome) Serialize(writer *data.EoWriter) (err error) {
 
 	// Bracer : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Bracer) != 2 {
+			err = fmt.Errorf("expected Bracer with length 2, got %d", len(s.Bracer))
+			return
+		}
+
 		if err = writer.AddShort(s.Bracer[ndx]); err != nil {
 			return
 		}
@@ -462,6 +477,11 @@ func (s *EquipmentPaperdoll) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Ring : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Ring) != 2 {
+			err = fmt.Errorf("expected Ring with length 2, got %d", len(s.Ring))
+			return
+		}
+
 		if err = writer.AddShort(s.Ring[ndx]); err != nil {
 			return
 		}
@@ -469,6 +489,11 @@ func (s *EquipmentPaperdoll) Serialize(writer *data.EoWriter) (err error) {
 
 	// Armlet : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Armlet) != 2 {
+			err = fmt.Errorf("expected Armlet with length 2, got %d", len(s.Armlet))
+			return
+		}
+
 		if err = writer.AddShort(s.Armlet[ndx]); err != nil {
 			return
 		}
@@ -476,6 +501,11 @@ func (s *EquipmentPaperdoll) Serialize(writer *data.EoWriter) (err error) {
 
 	// Bracer : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Bracer) != 2 {
+			err = fmt.Errorf("expected Bracer with length 2, got %d", len(s.Bracer))
+			return
+		}
+
 		if err = writer.AddShort(s.Bracer[ndx]); err != nil {
 			return
 		}
@@ -592,6 +622,10 @@ func (s *CharacterMapInfo) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// GuildTag : field : string
+	if len(s.GuildTag) != 3 {
+		err = fmt.Errorf("expected GuildTag with length 3, got %d", len(s.GuildTag))
+		return
+	}
 	if err = writer.AddFixedString(s.GuildTag, 3); err != nil {
 		return
 	}
@@ -1729,6 +1763,11 @@ func (s *ShopCraftItem) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Ingredients : array : CharItem
 	for ndx := 0; ndx < 4; ndx++ {
+		if len(s.Ingredients) != 4 {
+			err = fmt.Errorf("expected Ingredients with length 4, got %d", len(s.Ingredients))
+			return
+		}
+
 		if err = s.Ingredients[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -2588,6 +2627,11 @@ func (s *SkillLearn) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// SkillRequirements : array : short
 	for ndx := 0; ndx < 4; ndx++ {
+		if len(s.SkillRequirements) != 4 {
+			err = fmt.Errorf("expected SkillRequirements with length 4, got %d", len(s.SkillRequirements))
+			return
+		}
+
 		if err = writer.AddShort(s.SkillRequirements[ndx]); err != nil {
 			return
 		}

--- a/pkg/eolib/protocol/net/server/structs_generated.go
+++ b/pkg/eolib/protocol/net/server/structs_generated.go
@@ -1019,7 +1019,8 @@ func (s *NearbyInfo) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	// Npcs : array : NpcMapInfo
-	for ndx := 0; ndx < reader.Remaining()/6; ndx++ {
+	NpcsRemaining := reader.Remaining()
+	for ndx := 0; ndx < NpcsRemaining/6; ndx++ {
 		s.Npcs = append(s.Npcs, NpcMapInfo{})
 		if err = s.Npcs[ndx].Deserialize(reader); err != nil {
 			return
@@ -1030,7 +1031,8 @@ func (s *NearbyInfo) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	// Items : array : ItemMapInfo
-	for ndx := 0; ndx < reader.Remaining()/9; ndx++ {
+	ItemsRemaining := reader.Remaining()
+	for ndx := 0; ndx < ItemsRemaining/9; ndx++ {
 		s.Items = append(s.Items, ItemMapInfo{})
 		if err = s.Items[ndx].Deserialize(reader); err != nil {
 			return
@@ -2798,7 +2800,8 @@ func (s *TradeItemData) Deserialize(reader *data.EoReader) (err error) {
 	// PartnerPlayerId : field : short
 	s.PartnerPlayerId = reader.GetShort()
 	// PartnerItems : array : Item
-	for ndx := 0; ndx < reader.Remaining()/6; ndx++ {
+	PartnerItemsRemaining := reader.Remaining()
+	for ndx := 0; ndx < PartnerItemsRemaining/6; ndx++ {
 		s.PartnerItems = append(s.PartnerItems, net.Item{})
 		if err = s.PartnerItems[ndx].Deserialize(reader); err != nil {
 			return
@@ -2811,7 +2814,8 @@ func (s *TradeItemData) Deserialize(reader *data.EoReader) (err error) {
 	// YourPlayerId : field : short
 	s.YourPlayerId = reader.GetShort()
 	// YourItems : array : Item
-	for ndx := 0; ndx < reader.Remaining()/6; ndx++ {
+	YourItemsRemaining := reader.Remaining()
+	for ndx := 0; ndx < YourItemsRemaining/6; ndx++ {
 		s.YourItems = append(s.YourItems, net.Item{})
 		if err = s.YourItems[ndx].Deserialize(reader); err != nil {
 			return

--- a/pkg/eolib/protocol/net/server/structs_generated.go
+++ b/pkg/eolib/protocol/net/server/structs_generated.go
@@ -1109,10 +1109,9 @@ func (s *AvatarChange) Deserialize(reader *data.EoReader) (err error) {
 type NearbyInfo struct {
 	byteSize int
 
-	CharactersCount int
-	Characters      []CharacterMapInfo
-	Npcs            []NpcMapInfo
-	Items           []ItemMapInfo
+	Characters []CharacterMapInfo
+	Npcs       []NpcMapInfo
+	Items      []ItemMapInfo
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -1125,13 +1124,13 @@ func (s *NearbyInfo) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// CharactersCount : length : char
-	if err = writer.AddChar(s.CharactersCount); err != nil {
+	if err = writer.AddChar(len(s.Characters)); err != nil {
 		return
 	}
 	writer.SanitizeStrings = true
 	writer.AddByte(255)
 	// Characters : array : CharacterMapInfo
-	for ndx := 0; ndx < s.CharactersCount; ndx++ {
+	for ndx := 0; ndx < len(s.Characters); ndx++ {
 		if err = s.Characters[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -1163,13 +1162,13 @@ func (s *NearbyInfo) Deserialize(reader *data.EoReader) (err error) {
 
 	readerStartPosition := reader.Position()
 	// CharactersCount : length : char
-	s.CharactersCount = reader.GetChar()
+	charactersCount := reader.GetChar()
 	reader.SetIsChunked(true)
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
 	// Characters : array : CharacterMapInfo
-	for ndx := 0; ndx < s.CharactersCount; ndx++ {
+	for ndx := 0; ndx < charactersCount; ndx++ {
 		s.Characters = append(s.Characters, CharacterMapInfo{})
 		if err = s.Characters[ndx].Deserialize(reader); err != nil {
 			return
@@ -1287,8 +1286,7 @@ func (s *PubFile) Deserialize(reader *data.EoReader) (err error) {
 type PlayersList struct {
 	byteSize int
 
-	PlayersCount int
-	Players      []OnlinePlayer
+	Players []OnlinePlayer
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -1302,12 +1300,12 @@ func (s *PlayersList) Serialize(writer *data.EoWriter) (err error) {
 
 	writer.SanitizeStrings = true
 	// PlayersCount : length : short
-	if err = writer.AddShort(s.PlayersCount); err != nil {
+	if err = writer.AddShort(len(s.Players)); err != nil {
 		return
 	}
 	writer.AddByte(255)
 	// Players : array : OnlinePlayer
-	for ndx := 0; ndx < s.PlayersCount; ndx++ {
+	for ndx := 0; ndx < len(s.Players); ndx++ {
 		if err = s.Players[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -1325,12 +1323,12 @@ func (s *PlayersList) Deserialize(reader *data.EoReader) (err error) {
 	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayersCount : length : short
-	s.PlayersCount = reader.GetShort()
+	playersCount := reader.GetShort()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
 	// Players : array : OnlinePlayer
-	for ndx := 0; ndx < s.PlayersCount; ndx++ {
+	for ndx := 0; ndx < playersCount; ndx++ {
 		s.Players = append(s.Players, OnlinePlayer{})
 		if err = s.Players[ndx].Deserialize(reader); err != nil {
 			return
@@ -1350,8 +1348,7 @@ func (s *PlayersList) Deserialize(reader *data.EoReader) (err error) {
 type PlayersListFriends struct {
 	byteSize int
 
-	PlayersCount int
-	Players      []string
+	Players []string
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -1365,12 +1362,12 @@ func (s *PlayersListFriends) Serialize(writer *data.EoWriter) (err error) {
 
 	writer.SanitizeStrings = true
 	// PlayersCount : length : short
-	if err = writer.AddShort(s.PlayersCount); err != nil {
+	if err = writer.AddShort(len(s.Players)); err != nil {
 		return
 	}
 	writer.AddByte(255)
 	// Players : array : string
-	for ndx := 0; ndx < s.PlayersCount; ndx++ {
+	for ndx := 0; ndx < len(s.Players); ndx++ {
 		if err = writer.AddString(s.Players[ndx]); err != nil {
 			return
 		}
@@ -1388,12 +1385,12 @@ func (s *PlayersListFriends) Deserialize(reader *data.EoReader) (err error) {
 	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayersCount : length : short
-	s.PlayersCount = reader.GetShort()
+	playersCount := reader.GetShort()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
 	// Players : array : string
-	for ndx := 0; ndx < s.PlayersCount; ndx++ {
+	for ndx := 0; ndx < playersCount; ndx++ {
 		s.Players = append(s.Players, "")
 		if s.Players[ndx], err = reader.GetString(); err != nil {
 			return
@@ -3546,9 +3543,8 @@ func (s *NpcUpdateAttack) Deserialize(reader *data.EoReader) (err error) {
 type NpcUpdateChat struct {
 	byteSize int
 
-	NpcIndex      int
-	MessageLength int
-	Message       string
+	NpcIndex int
+	Message  string
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -3565,11 +3561,11 @@ func (s *NpcUpdateChat) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// MessageLength : length : char
-	if err = writer.AddChar(s.MessageLength); err != nil {
+	if err = writer.AddChar(len(s.Message)); err != nil {
 		return
 	}
 	// Message : field : string
-	if err = writer.AddFixedString(s.Message, s.MessageLength); err != nil {
+	if err = writer.AddFixedString(s.Message, len(s.Message)); err != nil {
 		return
 	}
 	return
@@ -3583,9 +3579,9 @@ func (s *NpcUpdateChat) Deserialize(reader *data.EoReader) (err error) {
 	// NpcIndex : field : char
 	s.NpcIndex = reader.GetChar()
 	// MessageLength : length : char
-	s.MessageLength = reader.GetChar()
+	messageLength := reader.GetChar()
 	// Message : field : string
-	if s.Message, err = reader.GetFixedString(s.MessageLength); err != nil {
+	if s.Message, err = reader.GetFixedString(messageLength); err != nil {
 		return
 	}
 

--- a/pkg/eolib/protocol/net/server/structs_generated.go
+++ b/pkg/eolib/protocol/net/server/structs_generated.go
@@ -9,8 +9,15 @@ import (
 
 // BigCoords :: Map coordinates with 2-byte values.
 type BigCoords struct {
+	byteSize int
+
 	X int
 	Y int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BigCoords) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BigCoords) Serialize(writer *data.EoWriter) (err error) {
@@ -32,21 +39,30 @@ func (s *BigCoords) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// X : field : short
 	s.X = reader.GetShort()
 	// Y : field : short
 	s.Y = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EquipmentChange ::  Player equipment data. Sent when a player's visible equipment changes. Note that these values are graphic IDs.
 type EquipmentChange struct {
+	byteSize int
+
 	Boots  int
 	Armor  int
 	Hat    int
 	Weapon int
 	Shield int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EquipmentChange) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EquipmentChange) Serialize(writer *data.EoWriter) (err error) {
@@ -80,6 +96,7 @@ func (s *EquipmentChange) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Boots : field : short
 	s.Boots = reader.GetShort()
 	// Armor : field : short
@@ -90,12 +107,15 @@ func (s *EquipmentChange) Deserialize(reader *data.EoReader) (err error) {
 	s.Weapon = reader.GetShort()
 	// Shield : field : short
 	s.Shield = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EquipmentMapInfo ::  Player equipment data. Sent with map information about a nearby character. Note that these values are graphic IDs.
 type EquipmentMapInfo struct {
+	byteSize int
+
 	Boots int
 
 	Armor int
@@ -103,6 +123,11 @@ type EquipmentMapInfo struct {
 	Hat    int
 	Shield int
 	Weapon int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EquipmentMapInfo) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EquipmentMapInfo) Serialize(writer *data.EoWriter) (err error) {
@@ -152,6 +177,7 @@ func (s *EquipmentMapInfo) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Boots : field : short
 	s.Boots = reader.GetShort()
 	// 0 : field : short
@@ -170,17 +196,25 @@ func (s *EquipmentMapInfo) Deserialize(reader *data.EoReader) (err error) {
 	s.Shield = reader.GetShort()
 	// Weapon : field : short
 	s.Weapon = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EquipmentCharacterSelect ::  Player equipment data. Sent with a character in the character selection list. Note that these values are graphic IDs.
 type EquipmentCharacterSelect struct {
+	byteSize int
+
 	Boots  int
 	Armor  int
 	Hat    int
 	Shield int
 	Weapon int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EquipmentCharacterSelect) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EquipmentCharacterSelect) Serialize(writer *data.EoWriter) (err error) {
@@ -214,6 +248,7 @@ func (s *EquipmentCharacterSelect) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Boots : field : short
 	s.Boots = reader.GetShort()
 	// Armor : field : short
@@ -224,12 +259,15 @@ func (s *EquipmentCharacterSelect) Deserialize(reader *data.EoReader) (err error
 	s.Shield = reader.GetShort()
 	// Weapon : field : short
 	s.Weapon = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // EquipmentWelcome ::  Player equipment data. Sent upon selecting a character and entering the game. Note that these values are item IDs.
 type EquipmentWelcome struct {
+	byteSize int
+
 	Boots     int
 	Gloves    int
 	Accessory int
@@ -242,6 +280,11 @@ type EquipmentWelcome struct {
 	Ring      []int
 	Armlet    []int
 	Bracer    []int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EquipmentWelcome) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EquipmentWelcome) Serialize(writer *data.EoWriter) (err error) {
@@ -312,6 +355,7 @@ func (s *EquipmentWelcome) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Boots : field : short
 	s.Boots = reader.GetShort()
 	// Gloves : field : short
@@ -348,11 +392,15 @@ func (s *EquipmentWelcome) Deserialize(reader *data.EoReader) (err error) {
 		s.Bracer[ndx] = reader.GetShort()
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // EquipmentPaperdoll ::  Player equipment data. Sent with information about a player's paperdoll. Note that these values are item IDs.
 type EquipmentPaperdoll struct {
+	byteSize int
+
 	Boots     int
 	Accessory int
 	Gloves    int
@@ -365,6 +413,11 @@ type EquipmentPaperdoll struct {
 	Ring      []int
 	Armlet    []int
 	Bracer    []int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EquipmentPaperdoll) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EquipmentPaperdoll) Serialize(writer *data.EoWriter) (err error) {
@@ -435,6 +488,7 @@ func (s *EquipmentPaperdoll) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Boots : field : short
 	s.Boots = reader.GetShort()
 	// Accessory : field : short
@@ -471,11 +525,15 @@ func (s *EquipmentPaperdoll) Deserialize(reader *data.EoReader) (err error) {
 		s.Bracer[ndx] = reader.GetShort()
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // CharacterMapInfo ::  Information about a nearby character. The official client skips these if they're under 42 bytes in length.
 type CharacterMapInfo struct {
+	byteSize int
+
 	Name       string
 	PlayerId   int
 	MapId      int
@@ -496,6 +554,11 @@ type CharacterMapInfo struct {
 	SitState   SitState
 	Invisible  bool
 	WarpEffect *WarpEffect
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterMapInfo) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterMapInfo) Serialize(writer *data.EoWriter) (err error) {
@@ -600,6 +663,7 @@ func (s *CharacterMapInfo) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
@@ -662,16 +726,24 @@ func (s *CharacterMapInfo) Deserialize(reader *data.EoReader) (err error) {
 		*s.WarpEffect = WarpEffect(reader.GetChar())
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcMapInfo :: Information about a nearby NPC.
 type NpcMapInfo struct {
+	byteSize int
+
 	Index     int
 	Id        int
 	Coords    protocol.Coords
 	Direction protocol.Direction
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcMapInfo) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcMapInfo) Serialize(writer *data.EoWriter) (err error) {
@@ -701,6 +773,7 @@ func (s *NpcMapInfo) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Index : field : char
 	s.Index = reader.GetChar()
 	// Id : field : short
@@ -711,16 +784,24 @@ func (s *NpcMapInfo) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ItemMapInfo :: Information about a nearby item on the ground.
 type ItemMapInfo struct {
+	byteSize int
+
 	Uid    int
 	Id     int
 	Coords protocol.Coords
 	Amount int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ItemMapInfo) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ItemMapInfo) Serialize(writer *data.EoWriter) (err error) {
@@ -750,6 +831,7 @@ func (s *ItemMapInfo) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Uid : field : short
 	s.Uid = reader.GetShort()
 	// Id : field : short
@@ -760,12 +842,15 @@ func (s *ItemMapInfo) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// Amount : field : three
 	s.Amount = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // AvatarChange :: Information about a nearby player's appearance changing.
 type AvatarChange struct {
+	byteSize int
+
 	PlayerId       int
 	ChangeType     AvatarChangeType
 	Sound          bool
@@ -777,7 +862,14 @@ type ChangeTypeData interface {
 }
 
 type ChangeTypeDataEquipment struct {
+	byteSize int
+
 	Equipment EquipmentChange
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChangeTypeDataEquipment) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChangeTypeDataEquipment) Serialize(writer *data.EoWriter) (err error) {
@@ -795,17 +887,26 @@ func (s *ChangeTypeDataEquipment) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Equipment : field : EquipmentChange
 	if err = s.Equipment.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type ChangeTypeDataHair struct {
+	byteSize int
+
 	HairStyle int
 	HairColor int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChangeTypeDataHair) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChangeTypeDataHair) Serialize(writer *data.EoWriter) (err error) {
@@ -827,16 +928,25 @@ func (s *ChangeTypeDataHair) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// HairStyle : field : char
 	s.HairStyle = reader.GetChar()
 	// HairColor : field : char
 	s.HairColor = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 type ChangeTypeDataHairColor struct {
+	byteSize int
+
 	HairColor int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ChangeTypeDataHairColor) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ChangeTypeDataHairColor) Serialize(writer *data.EoWriter) (err error) {
@@ -854,10 +964,17 @@ func (s *ChangeTypeDataHairColor) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// HairColor : field : char
 	s.HairColor = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *AvatarChange) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *AvatarChange) Serialize(writer *data.EoWriter) (err error) {
@@ -921,6 +1038,7 @@ func (s *AvatarChange) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// ChangeType : field : AvatarChangeType
@@ -948,16 +1066,24 @@ func (s *AvatarChange) Deserialize(reader *data.EoReader) (err error) {
 			return
 		}
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NearbyInfo :: Information about nearby entities.
 type NearbyInfo struct {
+	byteSize int
+
 	CharactersCount int
 	Characters      []CharacterMapInfo
 	Npcs            []NpcMapInfo
 	Items           []ItemMapInfo
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NearbyInfo) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NearbyInfo) Serialize(writer *data.EoWriter) (err error) {
@@ -1001,6 +1127,7 @@ func (s *NearbyInfo) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// CharactersCount : length : char
 	s.CharactersCount = reader.GetChar()
 	reader.SetIsChunked(true)
@@ -1040,13 +1167,21 @@ func (s *NearbyInfo) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // MapFile :: A map file (EMF).
 type MapFile struct {
+	byteSize int
+
 	Content []byte
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapFile) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapFile) Serialize(writer *data.EoWriter) (err error) {
@@ -1064,16 +1199,25 @@ func (s *MapFile) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Content : field : blob
 	s.Content = reader.GetBytes(reader.Remaining())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PubFile :: A pub file (EIF, ENF, ECF, ESF).
 type PubFile struct {
+	byteSize int
+
 	FileId  int
 	Content []byte
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PubFile) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PubFile) Serialize(writer *data.EoWriter) (err error) {
@@ -1095,18 +1239,27 @@ func (s *PubFile) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// FileId : field : char
 	s.FileId = reader.GetChar()
 	// Content : field : blob
 	s.Content = reader.GetBytes(reader.Remaining())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersList :: Information about online players.
 type PlayersList struct {
+	byteSize int
+
 	PlayersCount int
 	Players      []OnlinePlayer
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersList) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersList) Serialize(writer *data.EoWriter) (err error) {
@@ -1135,6 +1288,7 @@ func (s *PlayersList) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayersCount : length : short
 	s.PlayersCount = reader.GetShort()
@@ -1153,14 +1307,22 @@ func (s *PlayersList) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayersListFriends ::  Information about online players. Sent in reply to friends list requests.
 type PlayersListFriends struct {
+	byteSize int
+
 	PlayersCount int
 	Players      []string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayersListFriends) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayersListFriends) Serialize(writer *data.EoWriter) (err error) {
@@ -1189,6 +1351,7 @@ func (s *PlayersListFriends) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayersCount : length : short
 	s.PlayersCount = reader.GetShort()
@@ -1208,18 +1371,26 @@ func (s *PlayersListFriends) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // OnlinePlayer :: A player in the online list.
 type OnlinePlayer struct {
+	byteSize int
+
 	Name     string
 	Title    string
 	Level    int
 	Icon     CharacterIcon
 	ClassId  int
 	GuildTag string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *OnlinePlayer) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *OnlinePlayer) Serialize(writer *data.EoWriter) (err error) {
@@ -1261,6 +1432,7 @@ func (s *OnlinePlayer) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
@@ -1290,12 +1462,15 @@ func (s *OnlinePlayer) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterSelectionListEntry :: Character selection screen character.
 type CharacterSelectionListEntry struct {
+	byteSize int
+
 	Name      string
 	Id        int
 	Level     int
@@ -1305,6 +1480,11 @@ type CharacterSelectionListEntry struct {
 	Skin      int
 	Admin     protocol.AdminLevel
 	Equipment EquipmentCharacterSelect
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterSelectionListEntry) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterSelectionListEntry) Serialize(writer *data.EoWriter) (err error) {
@@ -1357,6 +1537,7 @@ func (s *CharacterSelectionListEntry) Deserialize(reader *data.EoReader) (err er
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
@@ -1385,12 +1566,15 @@ func (s *CharacterSelectionListEntry) Deserialize(reader *data.EoReader) (err er
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ServerSettings :: Settings sent with WELCOME_REPLY packet.
 type ServerSettings struct {
+	byteSize int
+
 	JailMap                   int
 	RescueMap                 int
 	RescueCoords              protocol.Coords
@@ -1398,6 +1582,11 @@ type ServerSettings struct {
 	GuardianFloodRate         int
 	GameMasterFloodRate       int
 	HighGameMasterFloodRate   int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ServerSettings) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ServerSettings) Serialize(writer *data.EoWriter) (err error) {
@@ -1439,6 +1628,7 @@ func (s *ServerSettings) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// JailMap : field : short
 	s.JailMap = reader.GetShort()
 	// RescueMap : field : short
@@ -1455,16 +1645,24 @@ func (s *ServerSettings) Deserialize(reader *data.EoReader) (err error) {
 	s.GameMasterFloodRate = reader.GetShort()
 	// HighGameMasterFloodRate : field : short
 	s.HighGameMasterFloodRate = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopTradeItem :: An item that a shop can buy or sell.
 type ShopTradeItem struct {
+	byteSize int
+
 	ItemId       int
 	BuyPrice     int
 	SellPrice    int
 	MaxBuyAmount int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopTradeItem) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopTradeItem) Serialize(writer *data.EoWriter) (err error) {
@@ -1494,6 +1692,7 @@ func (s *ShopTradeItem) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
 	// BuyPrice : field : three
@@ -1502,14 +1701,22 @@ func (s *ShopTradeItem) Deserialize(reader *data.EoReader) (err error) {
 	s.SellPrice = reader.GetThree()
 	// MaxBuyAmount : field : char
 	s.MaxBuyAmount = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopCraftItem :: An item that a shop can craft.
 type ShopCraftItem struct {
+	byteSize int
+
 	ItemId      int
 	Ingredients []net.CharItem
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopCraftItem) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopCraftItem) Serialize(writer *data.EoWriter) (err error) {
@@ -1534,6 +1741,7 @@ func (s *ShopCraftItem) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
 	// Ingredients : array : CharItem
@@ -1544,13 +1752,22 @@ func (s *ShopCraftItem) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // ShopSoldItem :: A sold item when selling an item to a shop.
 type ShopSoldItem struct {
+	byteSize int
+
 	Amount int
 	Id     int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopSoldItem) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopSoldItem) Serialize(writer *data.EoWriter) (err error) {
@@ -1572,22 +1789,31 @@ func (s *ShopSoldItem) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Amount : field : int
 	s.Amount = reader.GetInt()
 	// Id : field : short
 	s.Id = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterBaseStats :: The 6 base character stats.
 type CharacterBaseStats struct {
+	byteSize int
+
 	Str  int
 	Intl int
 	Wis  int
 	Agi  int
 	Con  int
 	Cha  int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterBaseStats) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterBaseStats) Serialize(writer *data.EoWriter) (err error) {
@@ -1625,6 +1851,7 @@ func (s *CharacterBaseStats) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Str : field : short
 	s.Str = reader.GetShort()
 	// Intl : field : short
@@ -1637,18 +1864,26 @@ func (s *CharacterBaseStats) Deserialize(reader *data.EoReader) (err error) {
 	s.Con = reader.GetShort()
 	// Cha : field : short
 	s.Cha = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterBaseStatsWelcome ::  The 6 base character stats. Sent upon selecting a character and entering the game.
 type CharacterBaseStatsWelcome struct {
+	byteSize int
+
 	Str  int
 	Wis  int
 	Intl int
 	Agi  int
 	Con  int
 	Cha  int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterBaseStatsWelcome) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterBaseStatsWelcome) Serialize(writer *data.EoWriter) (err error) {
@@ -1686,6 +1921,7 @@ func (s *CharacterBaseStatsWelcome) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Str : field : short
 	s.Str = reader.GetShort()
 	// Wis : field : short
@@ -1698,17 +1934,25 @@ func (s *CharacterBaseStatsWelcome) Deserialize(reader *data.EoReader) (err erro
 	s.Con = reader.GetShort()
 	// Cha : field : short
 	s.Cha = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterSecondaryStats :: The 5 secondary character stats.
 type CharacterSecondaryStats struct {
+	byteSize int
+
 	MinDamage int
 	MaxDamage int
 	Accuracy  int
 	Evade     int
 	Armor     int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterSecondaryStats) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterSecondaryStats) Serialize(writer *data.EoWriter) (err error) {
@@ -1742,6 +1986,7 @@ func (s *CharacterSecondaryStats) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MinDamage : field : short
 	s.MinDamage = reader.GetShort()
 	// MaxDamage : field : short
@@ -1752,17 +1997,25 @@ func (s *CharacterSecondaryStats) Deserialize(reader *data.EoReader) (err error)
 	s.Evade = reader.GetShort()
 	// Armor : field : short
 	s.Armor = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterSecondaryStatsInfoLookup ::  The 5 secondary character stats. Sent with character info lookups.
 type CharacterSecondaryStatsInfoLookup struct {
+	byteSize int
+
 	MaxDamage int
 	MinDamage int
 	Accuracy  int
 	Evade     int
 	Armor     int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterSecondaryStatsInfoLookup) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterSecondaryStatsInfoLookup) Serialize(writer *data.EoWriter) (err error) {
@@ -1796,6 +2049,7 @@ func (s *CharacterSecondaryStatsInfoLookup) Deserialize(reader *data.EoReader) (
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MaxDamage : field : short
 	s.MaxDamage = reader.GetShort()
 	// MinDamage : field : short
@@ -1806,18 +2060,26 @@ func (s *CharacterSecondaryStatsInfoLookup) Deserialize(reader *data.EoReader) (
 	s.Evade = reader.GetShort()
 	// Armor : field : short
 	s.Armor = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterElementalStats :: The 6 elemental character stats.
 type CharacterElementalStats struct {
+	byteSize int
+
 	Light int
 	Dark  int
 	Fire  int
 	Water int
 	Earth int
 	Wind  int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterElementalStats) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterElementalStats) Serialize(writer *data.EoWriter) (err error) {
@@ -1855,6 +2117,7 @@ func (s *CharacterElementalStats) Deserialize(reader *data.EoReader) (err error)
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Light : field : short
 	s.Light = reader.GetShort()
 	// Dark : field : short
@@ -1867,12 +2130,15 @@ func (s *CharacterElementalStats) Deserialize(reader *data.EoReader) (err error)
 	s.Earth = reader.GetShort()
 	// Wind : field : short
 	s.Wind = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterStatsReset ::  Character stats data. Sent when resetting stats and skills at a skill master NPC.
 type CharacterStatsReset struct {
+	byteSize int
+
 	StatPoints  int
 	SkillPoints int
 	Hp          int
@@ -1882,6 +2148,11 @@ type CharacterStatsReset struct {
 	MaxSp       int
 	Base        CharacterBaseStats
 	Secondary   CharacterSecondaryStats
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterStatsReset) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterStatsReset) Serialize(writer *data.EoWriter) (err error) {
@@ -1931,6 +2202,7 @@ func (s *CharacterStatsReset) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// StatPoints : field : short
 	s.StatPoints = reader.GetShort()
 	// SkillPoints : field : short
@@ -1953,12 +2225,15 @@ func (s *CharacterStatsReset) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Secondary.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterStatsWelcome ::  Character stats data. Sent upon selecting a character and entering the game.
 type CharacterStatsWelcome struct {
+	byteSize int
+
 	Hp          int
 	MaxHp       int
 	Tp          int
@@ -1969,6 +2244,11 @@ type CharacterStatsWelcome struct {
 	Karma       int
 	Secondary   CharacterSecondaryStats
 	Base        CharacterBaseStatsWelcome
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterStatsWelcome) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterStatsWelcome) Serialize(writer *data.EoWriter) (err error) {
@@ -2022,6 +2302,7 @@ func (s *CharacterStatsWelcome) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Hp : field : short
 	s.Hp = reader.GetShort()
 	// MaxHp : field : short
@@ -2046,18 +2327,26 @@ func (s *CharacterStatsWelcome) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Base.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterStatsUpdate ::  Character stats data. Sent when stats are updated.
 type CharacterStatsUpdate struct {
+	byteSize int
+
 	BaseStats      CharacterBaseStats
 	MaxHp          int
 	MaxTp          int
 	MaxSp          int
 	MaxWeight      int
 	SecondaryStats CharacterSecondaryStats
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterStatsUpdate) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterStatsUpdate) Serialize(writer *data.EoWriter) (err error) {
@@ -2095,6 +2384,7 @@ func (s *CharacterStatsUpdate) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// BaseStats : field : CharacterBaseStats
 	if err = s.BaseStats.Deserialize(reader); err != nil {
 		return
@@ -2111,12 +2401,15 @@ func (s *CharacterStatsUpdate) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.SecondaryStats.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterStatsInfoLookup ::  Character stats data. Sent with character info lookups.
 type CharacterStatsInfoLookup struct {
+	byteSize int
+
 	Hp             int
 	MaxHp          int
 	Tp             int
@@ -2124,6 +2417,11 @@ type CharacterStatsInfoLookup struct {
 	BaseStats      CharacterBaseStats
 	SecondaryStats CharacterSecondaryStatsInfoLookup
 	ElementalStats CharacterElementalStats
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterStatsInfoLookup) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterStatsInfoLookup) Serialize(writer *data.EoWriter) (err error) {
@@ -2165,6 +2463,7 @@ func (s *CharacterStatsInfoLookup) Deserialize(reader *data.EoReader) (err error
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Hp : field : short
 	s.Hp = reader.GetShort()
 	// MaxHp : field : short
@@ -2185,16 +2484,24 @@ func (s *CharacterStatsInfoLookup) Deserialize(reader *data.EoReader) (err error
 	if err = s.ElementalStats.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterStatsEquipmentChange ::  Character stats data. Sent when an item is equipped or unequipped.
 type CharacterStatsEquipmentChange struct {
+	byteSize int
+
 	MaxHp          int
 	MaxTp          int
 	BaseStats      CharacterBaseStats
 	SecondaryStats CharacterSecondaryStats
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterStatsEquipmentChange) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterStatsEquipmentChange) Serialize(writer *data.EoWriter) (err error) {
@@ -2224,6 +2531,7 @@ func (s *CharacterStatsEquipmentChange) Deserialize(reader *data.EoReader) (err 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MaxHp : field : short
 	s.MaxHp = reader.GetShort()
 	// MaxTp : field : short
@@ -2236,18 +2544,26 @@ func (s *CharacterStatsEquipmentChange) Deserialize(reader *data.EoReader) (err 
 	if err = s.SecondaryStats.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SkillLearn :: A skill that can be learned from a skill master NPC.
 type SkillLearn struct {
+	byteSize int
+
 	Id                int
 	LevelRequirement  int
 	ClassRequirement  int
 	Cost              int
 	SkillRequirements []int
 	StatRequirements  CharacterBaseStats
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SkillLearn) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SkillLearn) Serialize(writer *data.EoWriter) (err error) {
@@ -2288,6 +2604,7 @@ func (s *SkillLearn) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Id : field : short
 	s.Id = reader.GetShort()
 	// LevelRequirement : field : char
@@ -2306,15 +2623,23 @@ func (s *SkillLearn) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.StatRequirements.Deserialize(reader); err != nil {
 		return
 	}
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // BoardPostListing :: An entry in the list of town board posts.
 type BoardPostListing struct {
+	byteSize int
+
 	PostId  int
 	Author  string
 	Subject string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *BoardPostListing) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *BoardPostListing) Serialize(writer *data.EoWriter) (err error) {
@@ -2344,6 +2669,7 @@ func (s *BoardPostListing) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PostId : field : short
 	s.PostId = reader.GetShort()
@@ -2364,12 +2690,15 @@ func (s *BoardPostListing) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharacterDetails :: Information displayed on the paperdoll and book.
 type CharacterDetails struct {
+	byteSize int
+
 	Name      string
 	Home      string
 	Partner   string
@@ -2380,6 +2709,11 @@ type CharacterDetails struct {
 	ClassId   int
 	Gender    protocol.Gender
 	Admin     protocol.AdminLevel
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharacterDetails) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharacterDetails) Serialize(writer *data.EoWriter) (err error) {
@@ -2441,6 +2775,7 @@ func (s *CharacterDetails) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
@@ -2499,17 +2834,25 @@ func (s *CharacterDetails) Deserialize(reader *data.EoReader) (err error) {
 	// Admin : field : AdminLevel
 	s.Admin = protocol.AdminLevel(reader.GetChar())
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PartyMember :: A member of the player's party.
 type PartyMember struct {
+	byteSize int
+
 	PlayerId     int
 	Leader       bool
 	Level        int
 	HpPercentage int
 	Name         string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyMember) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyMember) Serialize(writer *data.EoWriter) (err error) {
@@ -2549,6 +2892,7 @@ func (s *PartyMember) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Leader : field : bool
@@ -2566,14 +2910,23 @@ func (s *PartyMember) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // PartyExpShare :: EXP gain for a member of the player's party.
 type PartyExpShare struct {
+	byteSize int
+
 	PlayerId   int
 	Experience int
 	LevelUp    int //  A value greater than 0 is "new level" and indicates the player leveled up.
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PartyExpShare) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PartyExpShare) Serialize(writer *data.EoWriter) (err error) {
@@ -2599,20 +2952,29 @@ func (s *PartyExpShare) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// Experience : field : int
 	s.Experience = reader.GetInt()
 	// LevelUp : field : char
 	s.LevelUp = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildStaff :: Information about a guild staff member (recruiter or leader).
 type GuildStaff struct {
+	byteSize int
+
 	Rank int
 	Name string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildStaff) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildStaff) Serialize(writer *data.EoWriter) (err error) {
@@ -2637,6 +2999,7 @@ func (s *GuildStaff) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Rank : field : char
 	s.Rank = reader.GetChar()
@@ -2649,15 +3012,23 @@ func (s *GuildStaff) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GuildMember :: Information about a guild member.
 type GuildMember struct {
+	byteSize int
+
 	Rank     int
 	Name     string
 	RankName string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GuildMember) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GuildMember) Serialize(writer *data.EoWriter) (err error) {
@@ -2687,6 +3058,7 @@ func (s *GuildMember) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Rank : field : char
 	s.Rank = reader.GetChar()
@@ -2707,15 +3079,23 @@ func (s *GuildMember) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GroupHealTargetPlayer :: Nearby player hit by a group heal spell.
 type GroupHealTargetPlayer struct {
+	byteSize int
+
 	PlayerId     int
 	HpPercentage int
 	Hp           int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GroupHealTargetPlayer) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GroupHealTargetPlayer) Serialize(writer *data.EoWriter) (err error) {
@@ -2741,22 +3121,31 @@ func (s *GroupHealTargetPlayer) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// HpPercentage : field : char
 	s.HpPercentage = reader.GetChar()
 	// Hp : field : short
 	s.Hp = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TradeItemData :: Trade window item data.
 type TradeItemData struct {
+	byteSize int
+
 	PartnerPlayerId int
 	PartnerItems    []net.Item
 	YourPlayerId    int
 	YourItems       []net.Item
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TradeItemData) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TradeItemData) Serialize(writer *data.EoWriter) (err error) {
@@ -2796,6 +3185,7 @@ func (s *TradeItemData) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PartnerPlayerId : field : short
 	s.PartnerPlayerId = reader.GetShort()
@@ -2826,12 +3216,15 @@ func (s *TradeItemData) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcKilledData :: Information about an NPC that has been killed.
 type NpcKilledData struct {
+	byteSize int
+
 	KillerId        int
 	KillerDirection protocol.Direction
 	NpcIndex        int
@@ -2840,6 +3233,11 @@ type NpcKilledData struct {
 	DropCoords      protocol.Coords
 	DropAmount      int
 	Damage          int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcKilledData) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcKilledData) Serialize(writer *data.EoWriter) (err error) {
@@ -2885,6 +3283,7 @@ func (s *NpcKilledData) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// KillerId : field : short
 	s.KillerId = reader.GetShort()
 	// KillerDirection : field : Direction
@@ -2903,18 +3302,26 @@ func (s *NpcKilledData) Deserialize(reader *data.EoReader) (err error) {
 	s.DropAmount = reader.GetInt()
 	// Damage : field : three
 	s.Damage = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // LevelUpStats :: Level and stat updates.
 type LevelUpStats struct {
+	byteSize int
+
 	Level       int
 	StatPoints  int
 	SkillPoints int
 	MaxHp       int
 	MaxTp       int
 	MaxSp       int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *LevelUpStats) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *LevelUpStats) Serialize(writer *data.EoWriter) (err error) {
@@ -2952,6 +3359,7 @@ func (s *LevelUpStats) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Level : field : char
 	s.Level = reader.GetChar()
 	// StatPoints : field : short
@@ -2964,15 +3372,23 @@ func (s *LevelUpStats) Deserialize(reader *data.EoReader) (err error) {
 	s.MaxTp = reader.GetShort()
 	// MaxSp : field : short
 	s.MaxSp = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcUpdatePosition :: An NPC walking.
 type NpcUpdatePosition struct {
+	byteSize int
+
 	NpcIndex  int
 	Coords    protocol.Coords
 	Direction protocol.Direction
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcUpdatePosition) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcUpdatePosition) Serialize(writer *data.EoWriter) (err error) {
@@ -2998,6 +3414,7 @@ func (s *NpcUpdatePosition) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : char
 	s.NpcIndex = reader.GetChar()
 	// Coords : field : Coords
@@ -3006,18 +3423,26 @@ func (s *NpcUpdatePosition) Deserialize(reader *data.EoReader) (err error) {
 	}
 	// Direction : field : Direction
 	s.Direction = protocol.Direction(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcUpdateAttack :: An NPC attacking.
 type NpcUpdateAttack struct {
+	byteSize int
+
 	NpcIndex     int
 	Killed       PlayerKilledState
 	Direction    protocol.Direction
 	PlayerId     int
 	Damage       int
 	HpPercentage int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcUpdateAttack) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcUpdateAttack) Serialize(writer *data.EoWriter) (err error) {
@@ -3055,6 +3480,7 @@ func (s *NpcUpdateAttack) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : char
 	s.NpcIndex = reader.GetChar()
 	// Killed : field : PlayerKilledState
@@ -3067,15 +3493,23 @@ func (s *NpcUpdateAttack) Deserialize(reader *data.EoReader) (err error) {
 	s.Damage = reader.GetThree()
 	// HpPercentage : field : char
 	s.HpPercentage = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // NpcUpdateChat :: An NPC talking.
 type NpcUpdateChat struct {
+	byteSize int
+
 	NpcIndex      int
 	MessageLength int
 	Message       string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *NpcUpdateChat) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *NpcUpdateChat) Serialize(writer *data.EoWriter) (err error) {
@@ -3101,6 +3535,7 @@ func (s *NpcUpdateChat) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcIndex : field : char
 	s.NpcIndex = reader.GetChar()
 	// MessageLength : length : char
@@ -3110,16 +3545,25 @@ func (s *NpcUpdateChat) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // QuestProgressEntry :: An entry in the Quest Progress window.
 type QuestProgressEntry struct {
+	byteSize int
+
 	Name        string
 	Description string
 	Icon        QuestRequirementIcon
 	Progress    int
 	Target      int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *QuestProgressEntry) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *QuestProgressEntry) Serialize(writer *data.EoWriter) (err error) {
@@ -3157,6 +3601,7 @@ func (s *QuestProgressEntry) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// Name : field : string
 	if s.Name, err = reader.GetString(); err != nil {
@@ -3181,14 +3626,22 @@ func (s *QuestProgressEntry) Deserialize(reader *data.EoReader) (err error) {
 	// Target : field : short
 	s.Target = reader.GetShort()
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // DialogQuestEntry :: An entry in the quest switcher.
 type DialogQuestEntry struct {
+	byteSize int
+
 	QuestId   int
 	QuestName string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *DialogQuestEntry) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *DialogQuestEntry) Serialize(writer *data.EoWriter) (err error) {
@@ -3210,6 +3663,7 @@ func (s *DialogQuestEntry) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// QuestId : field : short
 	s.QuestId = reader.GetShort()
 	// QuestName : field : string
@@ -3217,11 +3671,15 @@ func (s *DialogQuestEntry) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // DialogEntry :: An entry in a quest dialog.
 type DialogEntry struct {
+	byteSize int
+
 	EntryType     DialogEntryType
 	EntryTypeData EntryTypeData
 	Line          string
@@ -3232,7 +3690,14 @@ type EntryTypeData interface {
 }
 
 type EntryTypeDataLink struct {
+	byteSize int
+
 	LinkId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EntryTypeDataLink) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EntryTypeDataLink) Serialize(writer *data.EoWriter) (err error) {
@@ -3250,10 +3715,17 @@ func (s *EntryTypeDataLink) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// LinkId : field : short
 	s.LinkId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *DialogEntry) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *DialogEntry) Serialize(writer *data.EoWriter) (err error) {
@@ -3287,6 +3759,7 @@ func (s *DialogEntry) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// EntryType : field : DialogEntryType
 	s.EntryType = DialogEntryType(reader.GetShort())
 	switch s.EntryType {
@@ -3301,14 +3774,23 @@ func (s *DialogEntry) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // MapDrainDamageOther :: Another player taking damage from a map HP drain.
 type MapDrainDamageOther struct {
+	byteSize int
+
 	PlayerId     int
 	HpPercentage int
 	Damage       int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *MapDrainDamageOther) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *MapDrainDamageOther) Serialize(writer *data.EoWriter) (err error) {
@@ -3334,20 +3816,29 @@ func (s *MapDrainDamageOther) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// HpPercentage : field : char
 	s.HpPercentage = reader.GetChar()
 	// Damage : field : short
 	s.Damage = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // GlobalBackfillMessage :: A backfilled global chat message.
 type GlobalBackfillMessage struct {
+	byteSize int
+
 	PlayerName string
 	Message    string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *GlobalBackfillMessage) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *GlobalBackfillMessage) Serialize(writer *data.EoWriter) (err error) {
@@ -3372,6 +3863,7 @@ func (s *GlobalBackfillMessage) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
 	// PlayerName : field : string
 	if s.PlayerName, err = reader.GetString(); err != nil {
@@ -3387,14 +3879,22 @@ func (s *GlobalBackfillMessage) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	reader.SetIsChunked(false)
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // PlayerEffect :: An effect playing on a player.
 type PlayerEffect struct {
+	byteSize int
+
 	PlayerId int
 	EffectId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *PlayerEffect) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *PlayerEffect) Serialize(writer *data.EoWriter) (err error) {
@@ -3416,18 +3916,27 @@ func (s *PlayerEffect) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// PlayerId : field : short
 	s.PlayerId = reader.GetShort()
 	// EffectId : field : three
 	s.EffectId = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // TileEffect :: An effect playing on a tile.
 type TileEffect struct {
+	byteSize int
+
 	Coords   protocol.Coords
 	EffectId int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TileEffect) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TileEffect) Serialize(writer *data.EoWriter) (err error) {
@@ -3449,12 +3958,14 @@ func (s *TileEffect) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Coords : field : Coords
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
 	// EffectId : field : short
 	s.EffectId = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }

--- a/pkg/eolib/protocol/net/structs_generated.go
+++ b/pkg/eolib/protocol/net/structs_generated.go
@@ -4,9 +4,16 @@ import "github.com/ethanmoffat/eolib-go/pkg/eolib/data"
 
 // Version :: Client version.
 type Version struct {
+	byteSize int
+
 	Major int
 	Minor int
 	Patch int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *Version) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *Version) Serialize(writer *data.EoWriter) (err error) {
@@ -32,20 +39,29 @@ func (s *Version) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Major : field : char
 	s.Major = reader.GetChar()
 	// Minor : field : char
 	s.Minor = reader.GetChar()
 	// Patch : field : char
 	s.Patch = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // Weight :: Current carry weight and maximum carry capacity of a player.
 type Weight struct {
+	byteSize int
+
 	Current int
 	Max     int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *Weight) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *Weight) Serialize(writer *data.EoWriter) (err error) {
@@ -67,18 +83,27 @@ func (s *Weight) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Current : field : char
 	s.Current = reader.GetChar()
 	// Max : field : char
 	s.Max = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // Item :: An item reference with a 4-byte amount.
 type Item struct {
+	byteSize int
+
 	Id     int
 	Amount int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *Item) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *Item) Serialize(writer *data.EoWriter) (err error) {
@@ -100,18 +125,27 @@ func (s *Item) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Id : field : short
 	s.Id = reader.GetShort()
 	// Amount : field : int
 	s.Amount = reader.GetInt()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ThreeItem ::  An item reference with a 3-byte amount. Used for shops, lockers, and various item transfers.
 type ThreeItem struct {
+	byteSize int
+
 	Id     int
 	Amount int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ThreeItem) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ThreeItem) Serialize(writer *data.EoWriter) (err error) {
@@ -133,18 +167,27 @@ func (s *ThreeItem) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Id : field : short
 	s.Id = reader.GetShort()
 	// Amount : field : three
 	s.Amount = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // CharItem ::  An item reference with a 1-byte amount. Used for craft ingredients.
 type CharItem struct {
+	byteSize int
+
 	Id     int
 	Amount int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *CharItem) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *CharItem) Serialize(writer *data.EoWriter) (err error) {
@@ -166,18 +209,27 @@ func (s *CharItem) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Id : field : short
 	s.Id = reader.GetShort()
 	// Amount : field : char
 	s.Amount = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // Spell :: A spell known by the player.
 type Spell struct {
+	byteSize int
+
 	Id    int
 	Level int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *Spell) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *Spell) Serialize(writer *data.EoWriter) (err error) {
@@ -199,10 +251,12 @@ func (s *Spell) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// Id : field : short
 	s.Id = reader.GetShort()
 	// Level : field : short
 	s.Level = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }

--- a/pkg/eolib/protocol/pub/server/structs_generated.go
+++ b/pkg/eolib/protocol/pub/server/structs_generated.go
@@ -65,9 +65,8 @@ func (s *DropRecord) Deserialize(reader *data.EoReader) (err error) {
 type DropNpcRecord struct {
 	byteSize int
 
-	NpcId      int
-	DropsCount int
-	Drops      []DropRecord
+	NpcId int
+	Drops []DropRecord
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -84,11 +83,11 @@ func (s *DropNpcRecord) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// DropsCount : length : short
-	if err = writer.AddShort(s.DropsCount); err != nil {
+	if err = writer.AddShort(len(s.Drops)); err != nil {
 		return
 	}
 	// Drops : array : DropRecord
-	for ndx := 0; ndx < s.DropsCount; ndx++ {
+	for ndx := 0; ndx < len(s.Drops); ndx++ {
 		if err = s.Drops[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -105,9 +104,9 @@ func (s *DropNpcRecord) Deserialize(reader *data.EoReader) (err error) {
 	// NpcId : field : short
 	s.NpcId = reader.GetShort()
 	// DropsCount : length : short
-	s.DropsCount = reader.GetShort()
+	dropsCount := reader.GetShort()
 	// Drops : array : DropRecord
-	for ndx := 0; ndx < s.DropsCount; ndx++ {
+	for ndx := 0; ndx < dropsCount; ndx++ {
 		s.Drops = append(s.Drops, DropRecord{})
 		if err = s.Drops[ndx].Deserialize(reader); err != nil {
 			return
@@ -175,10 +174,8 @@ func (s *DropFile) Deserialize(reader *data.EoReader) (err error) {
 type InnQuestionRecord struct {
 	byteSize int
 
-	QuestionLength int
-	Question       string
-	AnswerLength   int
-	Answer         string
+	Question string
+	Answer   string
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -191,19 +188,19 @@ func (s *InnQuestionRecord) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// QuestionLength : length : char
-	if err = writer.AddChar(s.QuestionLength); err != nil {
+	if err = writer.AddChar(len(s.Question)); err != nil {
 		return
 	}
 	// Question : field : string
-	if err = writer.AddFixedString(s.Question, s.QuestionLength); err != nil {
+	if err = writer.AddFixedString(s.Question, len(s.Question)); err != nil {
 		return
 	}
 	// AnswerLength : length : char
-	if err = writer.AddChar(s.AnswerLength); err != nil {
+	if err = writer.AddChar(len(s.Answer)); err != nil {
 		return
 	}
 	// Answer : field : string
-	if err = writer.AddFixedString(s.Answer, s.AnswerLength); err != nil {
+	if err = writer.AddFixedString(s.Answer, len(s.Answer)); err != nil {
 		return
 	}
 	return
@@ -215,16 +212,16 @@ func (s *InnQuestionRecord) Deserialize(reader *data.EoReader) (err error) {
 
 	readerStartPosition := reader.Position()
 	// QuestionLength : length : char
-	s.QuestionLength = reader.GetChar()
+	questionLength := reader.GetChar()
 	// Question : field : string
-	if s.Question, err = reader.GetFixedString(s.QuestionLength); err != nil {
+	if s.Question, err = reader.GetFixedString(questionLength); err != nil {
 		return
 	}
 
 	// AnswerLength : length : char
-	s.AnswerLength = reader.GetChar()
+	answerLength := reader.GetChar()
 	// Answer : field : string
-	if s.Answer, err = reader.GetFixedString(s.AnswerLength); err != nil {
+	if s.Answer, err = reader.GetFixedString(answerLength); err != nil {
 		return
 	}
 
@@ -238,7 +235,6 @@ type InnRecord struct {
 	byteSize int
 
 	BehaviorId            int // Behavior ID of the NPC that runs the inn. 0 for default inn.
-	NameLength            int
 	Name                  string
 	SpawnMap              int  // ID of the map the player is sent to after respawning.
 	SpawnX                int  // X coordinate of the map the player is sent to after respawning.
@@ -267,11 +263,11 @@ func (s *InnRecord) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// NameLength : length : char
-	if err = writer.AddChar(s.NameLength); err != nil {
+	if err = writer.AddChar(len(s.Name)); err != nil {
 		return
 	}
 	// Name : field : string
-	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
+	if err = writer.AddFixedString(s.Name, len(s.Name)); err != nil {
 		return
 	}
 	// SpawnMap : field : short
@@ -343,9 +339,9 @@ func (s *InnRecord) Deserialize(reader *data.EoReader) (err error) {
 	// BehaviorId : field : short
 	s.BehaviorId = reader.GetShort()
 	// NameLength : length : char
-	s.NameLength = reader.GetChar()
+	nameLength := reader.GetChar()
 	// Name : field : string
-	if s.Name, err = reader.GetFixedString(s.NameLength); err != nil {
+	if s.Name, err = reader.GetFixedString(nameLength); err != nil {
 		return
 	}
 
@@ -560,12 +556,10 @@ type SkillMasterRecord struct {
 	byteSize int
 
 	BehaviorId       int // Behavior ID of the Skill Master NPC.
-	NameLength       int
 	Name             string
 	MinLevel         int // Minimum level required to use this Skill Master.
 	MaxLevel         int // Maximum level allowed to use this Skill Master.
 	ClassRequirement int // Class required to use this Skill Master.
-	SkillsCount      int
 	Skills           []SkillMasterSkillRecord
 }
 
@@ -583,11 +577,11 @@ func (s *SkillMasterRecord) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// NameLength : length : char
-	if err = writer.AddChar(s.NameLength); err != nil {
+	if err = writer.AddChar(len(s.Name)); err != nil {
 		return
 	}
 	// Name : field : string
-	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
+	if err = writer.AddFixedString(s.Name, len(s.Name)); err != nil {
 		return
 	}
 	// MinLevel : field : char
@@ -603,11 +597,11 @@ func (s *SkillMasterRecord) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// SkillsCount : length : short
-	if err = writer.AddShort(s.SkillsCount); err != nil {
+	if err = writer.AddShort(len(s.Skills)); err != nil {
 		return
 	}
 	// Skills : array : SkillMasterSkillRecord
-	for ndx := 0; ndx < s.SkillsCount; ndx++ {
+	for ndx := 0; ndx < len(s.Skills); ndx++ {
 		if err = s.Skills[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -624,9 +618,9 @@ func (s *SkillMasterRecord) Deserialize(reader *data.EoReader) (err error) {
 	// BehaviorId : field : short
 	s.BehaviorId = reader.GetShort()
 	// NameLength : length : char
-	s.NameLength = reader.GetChar()
+	nameLength := reader.GetChar()
 	// Name : field : string
-	if s.Name, err = reader.GetFixedString(s.NameLength); err != nil {
+	if s.Name, err = reader.GetFixedString(nameLength); err != nil {
 		return
 	}
 
@@ -637,9 +631,9 @@ func (s *SkillMasterRecord) Deserialize(reader *data.EoReader) (err error) {
 	// ClassRequirement : field : char
 	s.ClassRequirement = reader.GetChar()
 	// SkillsCount : length : short
-	s.SkillsCount = reader.GetShort()
+	skillsCount := reader.GetShort()
 	// Skills : array : SkillMasterSkillRecord
-	for ndx := 0; ndx < s.SkillsCount; ndx++ {
+	for ndx := 0; ndx < skillsCount; ndx++ {
 		s.Skills = append(s.Skills, SkillMasterSkillRecord{})
 		if err = s.Skills[ndx].Deserialize(reader); err != nil {
 			return
@@ -862,13 +856,10 @@ type ShopRecord struct {
 	byteSize int
 
 	BehaviorId       int
-	NameLength       int
 	Name             string
 	MinLevel         int // Minimum level required to use this shop.
 	MaxLevel         int // Maximum level allowed to use this shop.
 	ClassRequirement int // Class required to use this shop.
-	TradesCount      int
-	CraftsCount      int
 	Trades           []ShopTradeRecord
 	Crafts           []ShopCraftRecord
 }
@@ -887,11 +878,11 @@ func (s *ShopRecord) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// NameLength : length : char
-	if err = writer.AddChar(s.NameLength); err != nil {
+	if err = writer.AddChar(len(s.Name)); err != nil {
 		return
 	}
 	// Name : field : string
-	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
+	if err = writer.AddFixedString(s.Name, len(s.Name)); err != nil {
 		return
 	}
 	// MinLevel : field : char
@@ -907,22 +898,22 @@ func (s *ShopRecord) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// TradesCount : length : short
-	if err = writer.AddShort(s.TradesCount); err != nil {
+	if err = writer.AddShort(len(s.Trades)); err != nil {
 		return
 	}
 	// CraftsCount : length : char
-	if err = writer.AddChar(s.CraftsCount); err != nil {
+	if err = writer.AddChar(len(s.Crafts)); err != nil {
 		return
 	}
 	// Trades : array : ShopTradeRecord
-	for ndx := 0; ndx < s.TradesCount; ndx++ {
+	for ndx := 0; ndx < len(s.Trades); ndx++ {
 		if err = s.Trades[ndx].Serialize(writer); err != nil {
 			return
 		}
 	}
 
 	// Crafts : array : ShopCraftRecord
-	for ndx := 0; ndx < s.CraftsCount; ndx++ {
+	for ndx := 0; ndx < len(s.Crafts); ndx++ {
 		if err = s.Crafts[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -939,9 +930,9 @@ func (s *ShopRecord) Deserialize(reader *data.EoReader) (err error) {
 	// BehaviorId : field : short
 	s.BehaviorId = reader.GetShort()
 	// NameLength : length : char
-	s.NameLength = reader.GetChar()
+	nameLength := reader.GetChar()
 	// Name : field : string
-	if s.Name, err = reader.GetFixedString(s.NameLength); err != nil {
+	if s.Name, err = reader.GetFixedString(nameLength); err != nil {
 		return
 	}
 
@@ -952,11 +943,11 @@ func (s *ShopRecord) Deserialize(reader *data.EoReader) (err error) {
 	// ClassRequirement : field : char
 	s.ClassRequirement = reader.GetChar()
 	// TradesCount : length : short
-	s.TradesCount = reader.GetShort()
+	tradesCount := reader.GetShort()
 	// CraftsCount : length : char
-	s.CraftsCount = reader.GetChar()
+	craftsCount := reader.GetChar()
 	// Trades : array : ShopTradeRecord
-	for ndx := 0; ndx < s.TradesCount; ndx++ {
+	for ndx := 0; ndx < tradesCount; ndx++ {
 		s.Trades = append(s.Trades, ShopTradeRecord{})
 		if err = s.Trades[ndx].Deserialize(reader); err != nil {
 			return
@@ -964,7 +955,7 @@ func (s *ShopRecord) Deserialize(reader *data.EoReader) (err error) {
 	}
 
 	// Crafts : array : ShopCraftRecord
-	for ndx := 0; ndx < s.CraftsCount; ndx++ {
+	for ndx := 0; ndx < craftsCount; ndx++ {
 		s.Crafts = append(s.Crafts, ShopCraftRecord{})
 		if err = s.Crafts[ndx].Deserialize(reader); err != nil {
 			return
@@ -1032,8 +1023,7 @@ func (s *ShopFile) Deserialize(reader *data.EoReader) (err error) {
 type TalkMessageRecord struct {
 	byteSize int
 
-	MessageLength int
-	Message       string
+	Message string
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -1046,11 +1036,11 @@ func (s *TalkMessageRecord) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// MessageLength : length : char
-	if err = writer.AddChar(s.MessageLength); err != nil {
+	if err = writer.AddChar(len(s.Message)); err != nil {
 		return
 	}
 	// Message : field : string
-	if err = writer.AddFixedString(s.Message, s.MessageLength); err != nil {
+	if err = writer.AddFixedString(s.Message, len(s.Message)); err != nil {
 		return
 	}
 	return
@@ -1062,9 +1052,9 @@ func (s *TalkMessageRecord) Deserialize(reader *data.EoReader) (err error) {
 
 	readerStartPosition := reader.Position()
 	// MessageLength : length : char
-	s.MessageLength = reader.GetChar()
+	messageLength := reader.GetChar()
 	// Message : field : string
-	if s.Message, err = reader.GetFixedString(s.MessageLength); err != nil {
+	if s.Message, err = reader.GetFixedString(messageLength); err != nil {
 		return
 	}
 
@@ -1077,10 +1067,9 @@ func (s *TalkMessageRecord) Deserialize(reader *data.EoReader) (err error) {
 type TalkRecord struct {
 	byteSize int
 
-	NpcId         int // ID of the NPC that will talk.
-	Rate          int // Chance that the NPC will talk (0-100).
-	MessagesCount int
-	Messages      []TalkMessageRecord
+	NpcId    int // ID of the NPC that will talk.
+	Rate     int // Chance that the NPC will talk (0-100).
+	Messages []TalkMessageRecord
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -1101,11 +1090,11 @@ func (s *TalkRecord) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// MessagesCount : length : char
-	if err = writer.AddChar(s.MessagesCount); err != nil {
+	if err = writer.AddChar(len(s.Messages)); err != nil {
 		return
 	}
 	// Messages : array : TalkMessageRecord
-	for ndx := 0; ndx < s.MessagesCount; ndx++ {
+	for ndx := 0; ndx < len(s.Messages); ndx++ {
 		if err = s.Messages[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -1124,9 +1113,9 @@ func (s *TalkRecord) Deserialize(reader *data.EoReader) (err error) {
 	// Rate : field : char
 	s.Rate = reader.GetChar()
 	// MessagesCount : length : char
-	s.MessagesCount = reader.GetChar()
+	messagesCount := reader.GetChar()
 	// Messages : array : TalkMessageRecord
-	for ndx := 0; ndx < s.MessagesCount; ndx++ {
+	for ndx := 0; ndx < messagesCount; ndx++ {
 		s.Messages = append(s.Messages, TalkMessageRecord{})
 		if err = s.Messages[ndx].Deserialize(reader); err != nil {
 			return

--- a/pkg/eolib/protocol/pub/server/structs_generated.go
+++ b/pkg/eolib/protocol/pub/server/structs_generated.go
@@ -1,6 +1,9 @@
 package serverpub
 
-import "github.com/ethanmoffat/eolib-go/pkg/eolib/data"
+import (
+	"fmt"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
+)
 
 // DropRecord :: Record of an item an NPC can drop when killed.
 type DropRecord struct {
@@ -319,6 +322,11 @@ func (s *InnRecord) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Questions : array : InnQuestionRecord
 	for ndx := 0; ndx < 3; ndx++ {
+		if len(s.Questions) != 3 {
+			err = fmt.Errorf("expected Questions with length 3, got %d", len(s.Questions))
+			return
+		}
+
 		if err = s.Questions[ndx].Serialize(writer); err != nil {
 			return
 		}
@@ -474,6 +482,11 @@ func (s *SkillMasterSkillRecord) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// SkillRequirements : array : short
 	for ndx := 0; ndx < 4; ndx++ {
+		if len(s.SkillRequirements) != 4 {
+			err = fmt.Errorf("expected SkillRequirements with length 4, got %d", len(s.SkillRequirements))
+			return
+		}
+
 		if err = writer.AddShort(s.SkillRequirements[ndx]); err != nil {
 			return
 		}
@@ -811,6 +824,11 @@ func (s *ShopCraftRecord) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Ingredients : array : ShopCraftIngredientRecord
 	for ndx := 0; ndx < 4; ndx++ {
+		if len(s.Ingredients) != 4 {
+			err = fmt.Errorf("expected Ingredients with length 4, got %d", len(s.Ingredients))
+			return
+		}
+
 		if err = s.Ingredients[ndx].Serialize(writer); err != nil {
 			return
 		}

--- a/pkg/eolib/protocol/pub/server/structs_generated.go
+++ b/pkg/eolib/protocol/pub/server/structs_generated.go
@@ -4,10 +4,17 @@ import "github.com/ethanmoffat/eolib-go/pkg/eolib/data"
 
 // DropRecord :: Record of an item an NPC can drop when killed.
 type DropRecord struct {
+	byteSize int
+
 	ItemId    int
 	MinAmount int
 	MaxAmount int
 	Rate      int // Chance (x in 64,000) of the item being dropped.
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *DropRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *DropRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -37,6 +44,7 @@ func (s *DropRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
 	// MinAmount : field : three
@@ -45,15 +53,23 @@ func (s *DropRecord) Deserialize(reader *data.EoReader) (err error) {
 	s.MaxAmount = reader.GetThree()
 	// Rate : field : short
 	s.Rate = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // DropNpcRecord :: Record of potential drops from an NPC.
 type DropNpcRecord struct {
+	byteSize int
+
 	NpcId      int
 	DropsCount int
 	Drops      []DropRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *DropNpcRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *DropNpcRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -82,6 +98,7 @@ func (s *DropNpcRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcId : field : short
 	s.NpcId = reader.GetShort()
 	// DropsCount : length : short
@@ -94,12 +111,21 @@ func (s *DropNpcRecord) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // DropFile :: Endless Drop File.
 type DropFile struct {
+	byteSize int
+
 	Npcs []DropNpcRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *DropFile) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *DropFile) Serialize(writer *data.EoWriter) (err error) {
@@ -124,6 +150,7 @@ func (s *DropFile) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// EDF : field : string
 	if _, err = reader.GetFixedString(3); err != nil {
 		return
@@ -136,15 +163,24 @@ func (s *DropFile) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // InnQuestionRecord :: Record of a question and answer that the player must answer to register citizenship with an inn.
 type InnQuestionRecord struct {
+	byteSize int
+
 	QuestionLength int
 	Question       string
 	AnswerLength   int
 	Answer         string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InnQuestionRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InnQuestionRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -174,6 +210,7 @@ func (s *InnQuestionRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// QuestionLength : length : char
 	s.QuestionLength = reader.GetChar()
 	// Question : field : string
@@ -188,11 +225,15 @@ func (s *InnQuestionRecord) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // InnRecord :: Record of Inn data in an Endless Inn File.
 type InnRecord struct {
+	byteSize int
+
 	BehaviorId            int // Behavior ID of the NPC that runs the inn. 0 for default inn.
 	NameLength            int
 	Name                  string
@@ -207,6 +248,11 @@ type InnRecord struct {
 	AlternateSpawnX       int
 	AlternateSpawnY       int
 	Questions             []InnQuestionRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InnRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InnRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -285,6 +331,7 @@ func (s *InnRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// BehaviorId : field : short
 	s.BehaviorId = reader.GetShort()
 	// NameLength : length : char
@@ -326,12 +373,21 @@ func (s *InnRecord) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // InnFile :: Endless Inn File.
 type InnFile struct {
+	byteSize int
+
 	Inns []InnRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *InnFile) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *InnFile) Serialize(writer *data.EoWriter) (err error) {
@@ -356,6 +412,7 @@ func (s *InnFile) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// EID : field : string
 	if _, err = reader.GetFixedString(3); err != nil {
 		return
@@ -368,11 +425,15 @@ func (s *InnFile) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // SkillMasterSkillRecord :: Record of a skill that a Skill Master NPC can teach.
 type SkillMasterSkillRecord struct {
+	byteSize int
+
 	SkillId           int
 	LevelRequirement  int // Level required to learn this skill.
 	ClassRequirement  int // Class required to learn this skill.
@@ -384,6 +445,11 @@ type SkillMasterSkillRecord struct {
 	AgiRequirement    int   // Agility required to learn this skill.
 	ConRequirement    int   // Constitution required to learn this skill.
 	ChaRequirement    int   // Charisma required to learn this skill.
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SkillMasterSkillRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SkillMasterSkillRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -444,6 +510,7 @@ func (s *SkillMasterSkillRecord) Deserialize(reader *data.EoReader) (err error) 
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// SkillId : field : short
 	s.SkillId = reader.GetShort()
 	// LevelRequirement : field : char
@@ -470,12 +537,15 @@ func (s *SkillMasterSkillRecord) Deserialize(reader *data.EoReader) (err error) 
 	s.ConRequirement = reader.GetShort()
 	// ChaRequirement : field : short
 	s.ChaRequirement = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // SkillMasterRecord :: Record of Skill Master data in an Endless Skill Master File.
 type SkillMasterRecord struct {
+	byteSize int
+
 	BehaviorId       int // Behavior ID of the Skill Master NPC.
 	NameLength       int
 	Name             string
@@ -484,6 +554,11 @@ type SkillMasterRecord struct {
 	ClassRequirement int // Class required to use this Skill Master.
 	SkillsCount      int
 	Skills           []SkillMasterSkillRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SkillMasterRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SkillMasterRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -532,6 +607,7 @@ func (s *SkillMasterRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// BehaviorId : field : short
 	s.BehaviorId = reader.GetShort()
 	// NameLength : length : char
@@ -557,12 +633,21 @@ func (s *SkillMasterRecord) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // SkillMasterFile :: Endless Skill Master File.
 type SkillMasterFile struct {
+	byteSize int
+
 	SkillMasters []SkillMasterRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SkillMasterFile) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *SkillMasterFile) Serialize(writer *data.EoWriter) (err error) {
@@ -587,6 +672,7 @@ func (s *SkillMasterFile) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// EMF : field : string
 	if _, err = reader.GetFixedString(3); err != nil {
 		return
@@ -599,15 +685,24 @@ func (s *SkillMasterFile) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // ShopTradeRecord :: Record of an item that can be bought or sold in a shop.
 type ShopTradeRecord struct {
+	byteSize int
+
 	ItemId    int
 	BuyPrice  int // How much it costs to buy the item from the shop.
 	SellPrice int // How much the shop will pay for the item.
 	MaxAmount int // Max amount of the item that can be bought or sold at one time.
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopTradeRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopTradeRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -637,6 +732,7 @@ func (s *ShopTradeRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
 	// BuyPrice : field : three
@@ -645,14 +741,22 @@ func (s *ShopTradeRecord) Deserialize(reader *data.EoReader) (err error) {
 	s.SellPrice = reader.GetThree()
 	// MaxAmount : field : char
 	s.MaxAmount = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopCraftIngredientRecord :: Record of an ingredient for crafting an item in a shop.
 type ShopCraftIngredientRecord struct {
+	byteSize int
+
 	ItemId int // Item ID of the craft ingredient, or 0 if the ingredient is not present.
 	Amount int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopCraftIngredientRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopCraftIngredientRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -674,18 +778,27 @@ func (s *ShopCraftIngredientRecord) Deserialize(reader *data.EoReader) (err erro
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
 	// Amount : field : char
 	s.Amount = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // ShopCraftRecord :: Record of an item that can be crafted in a shop.
 type ShopCraftRecord struct {
+	byteSize int
+
 	ItemId      int
 	Ingredients []ShopCraftIngredientRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopCraftRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopCraftRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -710,6 +823,7 @@ func (s *ShopCraftRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ItemId : field : short
 	s.ItemId = reader.GetShort()
 	// Ingredients : array : ShopCraftIngredientRecord
@@ -720,11 +834,15 @@ func (s *ShopCraftRecord) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // ShopRecord :: Record of Shop data in an Endless Shop File.
 type ShopRecord struct {
+	byteSize int
+
 	BehaviorId       int
 	NameLength       int
 	Name             string
@@ -735,6 +853,11 @@ type ShopRecord struct {
 	CraftsCount      int
 	Trades           []ShopTradeRecord
 	Crafts           []ShopCraftRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -794,6 +917,7 @@ func (s *ShopRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// BehaviorId : field : short
 	s.BehaviorId = reader.GetShort()
 	// NameLength : length : char
@@ -829,12 +953,21 @@ func (s *ShopRecord) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // ShopFile :: Endless Shop File.
 type ShopFile struct {
+	byteSize int
+
 	Shops []ShopRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *ShopFile) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *ShopFile) Serialize(writer *data.EoWriter) (err error) {
@@ -859,6 +992,7 @@ func (s *ShopFile) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ESF : field : string
 	if _, err = reader.GetFixedString(3); err != nil {
 		return
@@ -871,13 +1005,22 @@ func (s *ShopFile) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // TalkMessageRecord :: Record of a message that an NPC can say.
 type TalkMessageRecord struct {
+	byteSize int
+
 	MessageLength int
 	Message       string
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkMessageRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkMessageRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -899,6 +1042,7 @@ func (s *TalkMessageRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// MessageLength : length : char
 	s.MessageLength = reader.GetChar()
 	// Message : field : string
@@ -906,15 +1050,24 @@ func (s *TalkMessageRecord) Deserialize(reader *data.EoReader) (err error) {
 		return
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // TalkRecord :: Record of Talk data in an Endless Talk File.
 type TalkRecord struct {
+	byteSize int
+
 	NpcId         int // ID of the NPC that will talk.
 	Rate          int // Chance that the NPC will talk (0-100).
 	MessagesCount int
 	Messages      []TalkMessageRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -947,6 +1100,7 @@ func (s *TalkRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NpcId : field : short
 	s.NpcId = reader.GetShort()
 	// Rate : field : char
@@ -961,12 +1115,21 @@ func (s *TalkRecord) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // TalkFile :: Endless Talk File.
 type TalkFile struct {
+	byteSize int
+
 	Npcs []TalkRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *TalkFile) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *TalkFile) Serialize(writer *data.EoWriter) (err error) {
@@ -991,6 +1154,7 @@ func (s *TalkFile) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ETF : field : string
 	if _, err = reader.GetFixedString(3); err != nil {
 		return
@@ -1002,6 +1166,8 @@ func (s *TalkFile) Deserialize(reader *data.EoReader) (err error) {
 			return
 		}
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }

--- a/pkg/eolib/protocol/pub/structs_generated.go
+++ b/pkg/eolib/protocol/pub/structs_generated.go
@@ -1,6 +1,9 @@
 package pub
 
-import "github.com/ethanmoffat/eolib-go/pkg/eolib/data"
+import (
+	"fmt"
+	"github.com/ethanmoffat/eolib-go/pkg/eolib/data"
+)
 
 // EifRecord :: Record of Item data in an Endless Item File.
 type EifRecord struct {
@@ -352,6 +355,11 @@ func (s *Eif) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Rid) != 2 {
+			err = fmt.Errorf("expected Rid with length 2, got %d", len(s.Rid))
+			return
+		}
+
 		if err = writer.AddShort(s.Rid[ndx]); err != nil {
 			return
 		}
@@ -637,6 +645,11 @@ func (s *Enf) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Rid) != 2 {
+			err = fmt.Errorf("expected Rid with length 2, got %d", len(s.Rid))
+			return
+		}
+
 		if err = writer.AddShort(s.Rid[ndx]); err != nil {
 			return
 		}
@@ -818,6 +831,11 @@ func (s *Ecf) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Rid) != 2 {
+			err = fmt.Errorf("expected Rid with length 2, got %d", len(s.Rid))
+			return
+		}
+
 		if err = writer.AddShort(s.Rid[ndx]); err != nil {
 			return
 		}
@@ -1170,6 +1188,11 @@ func (s *Esf) Serialize(writer *data.EoWriter) (err error) {
 	}
 	// Rid : array : short
 	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.Rid) != 2 {
+			err = fmt.Errorf("expected Rid with length 2, got %d", len(s.Rid))
+			return
+		}
+
 		if err = writer.AddShort(s.Rid[ndx]); err != nil {
 			return
 		}

--- a/pkg/eolib/protocol/pub/structs_generated.go
+++ b/pkg/eolib/protocol/pub/structs_generated.go
@@ -4,6 +4,8 @@ import "github.com/ethanmoffat/eolib-go/pkg/eolib/data"
 
 // EifRecord :: Record of Item data in an Endless Item File.
 type EifRecord struct {
+	byteSize int
+
 	NameLength       int
 	Name             string
 	GraphicId        int
@@ -46,6 +48,11 @@ type EifRecord struct {
 	Weight           int
 
 	Size ItemSize
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EifRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EifRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -227,6 +234,7 @@ func (s *EifRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NameLength : length : char
 	s.NameLength = reader.GetChar()
 	// Name : field : string
@@ -314,16 +322,24 @@ func (s *EifRecord) Deserialize(reader *data.EoReader) (err error) {
 	reader.GetChar()
 	// Size : field : ItemSize
 	s.Size = ItemSize(reader.GetChar())
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // Eif :: Endless Item File.
 type Eif struct {
+	byteSize int
+
 	Rid             []int
 	TotalItemsCount int
 	Version         int
 	Items           []EifRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *Eif) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *Eif) Serialize(writer *data.EoWriter) (err error) {
@@ -363,6 +379,7 @@ func (s *Eif) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// EIF : field : string
 	if _, err = reader.GetFixedString(3); err != nil {
 		return
@@ -385,11 +402,15 @@ func (s *Eif) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // EnfRecord :: Record of NPC data in an Endless NPC File.
 type EnfRecord struct {
+	byteSize int
+
 	NameLength            int
 	Name                  string
 	GraphicId             int
@@ -412,6 +433,11 @@ type EnfRecord struct {
 	ElementWeaknessDamage int
 	Level                 int
 	Experience            int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EnfRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EnfRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -525,6 +551,7 @@ func (s *EnfRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NameLength : length : char
 	s.NameLength = reader.GetChar()
 	// Name : field : string
@@ -580,16 +607,24 @@ func (s *EnfRecord) Deserialize(reader *data.EoReader) (err error) {
 	s.Level = reader.GetChar()
 	// Experience : field : three
 	s.Experience = reader.GetThree()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // Enf :: Endless NPC File.
 type Enf struct {
+	byteSize int
+
 	Rid            []int
 	TotalNpcsCount int
 	Version        int
 	Npcs           []EnfRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *Enf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *Enf) Serialize(writer *data.EoWriter) (err error) {
@@ -629,6 +664,7 @@ func (s *Enf) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ENF : field : string
 	if _, err = reader.GetFixedString(3); err != nil {
 		return
@@ -651,11 +687,15 @@ func (s *Enf) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // EcfRecord :: Record of Class data in an Endless Class File.
 type EcfRecord struct {
+	byteSize int
+
 	NameLength int
 	Name       string
 	ParentType int
@@ -666,6 +706,11 @@ type EcfRecord struct {
 	Agi        int
 	Con        int
 	Cha        int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EcfRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EcfRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -719,6 +764,7 @@ func (s *EcfRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NameLength : length : char
 	s.NameLength = reader.GetChar()
 	// Name : field : string
@@ -742,16 +788,24 @@ func (s *EcfRecord) Deserialize(reader *data.EoReader) (err error) {
 	s.Con = reader.GetShort()
 	// Cha : field : short
 	s.Cha = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // Ecf :: Endless Class File.
 type Ecf struct {
+	byteSize int
+
 	Rid               []int
 	TotalClassesCount int
 	Version           int
 	Classes           []EcfRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *Ecf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *Ecf) Serialize(writer *data.EoWriter) (err error) {
@@ -791,6 +845,7 @@ func (s *Ecf) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ECF : field : string
 	if _, err = reader.GetFixedString(3); err != nil {
 		return
@@ -813,11 +868,15 @@ func (s *Ecf) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
+	s.byteSize = reader.Position() - readerStartPosition
+
 	return
 }
 
 // EsfRecord :: Record of Skill data in an Endless Skill File.
 type EsfRecord struct {
+	byteSize int
+
 	NameLength  int
 	ChantLength int
 	Name        string
@@ -852,6 +911,11 @@ type EsfRecord struct {
 	Agi           int
 	Con           int
 	Cha           int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *EsfRecord) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *EsfRecord) Serialize(writer *data.EoWriter) (err error) {
@@ -1001,6 +1065,7 @@ func (s *EsfRecord) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// NameLength : length : char
 	s.NameLength = reader.GetChar()
 	// ChantLength : length : char
@@ -1075,16 +1140,24 @@ func (s *EsfRecord) Deserialize(reader *data.EoReader) (err error) {
 	s.Con = reader.GetShort()
 	// Cha : field : short
 	s.Cha = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }
 
 // Esf :: Endless Skill File.
 type Esf struct {
+	byteSize int
+
 	Rid              []int
 	TotalSkillsCount int
 	Version          int
 	Skills           []EsfRecord
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *Esf) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *Esf) Serialize(writer *data.EoWriter) (err error) {
@@ -1124,6 +1197,7 @@ func (s *Esf) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// ESF : field : string
 	if _, err = reader.GetFixedString(3); err != nil {
 		return
@@ -1145,6 +1219,8 @@ func (s *Esf) Deserialize(reader *data.EoReader) (err error) {
 			return
 		}
 	}
+
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }

--- a/pkg/eolib/protocol/pub/structs_generated.go
+++ b/pkg/eolib/protocol/pub/structs_generated.go
@@ -9,7 +9,6 @@ import (
 type EifRecord struct {
 	byteSize int
 
-	NameLength       int
 	Name             string
 	GraphicId        int
 	Type             ItemType
@@ -63,11 +62,11 @@ func (s *EifRecord) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// NameLength : length : char
-	if err = writer.AddChar(s.NameLength); err != nil {
+	if err = writer.AddChar(len(s.Name)); err != nil {
 		return
 	}
 	// Name : field : string
-	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
+	if err = writer.AddFixedString(s.Name, len(s.Name)); err != nil {
 		return
 	}
 	// GraphicId : field : short
@@ -239,9 +238,9 @@ func (s *EifRecord) Deserialize(reader *data.EoReader) (err error) {
 
 	readerStartPosition := reader.Position()
 	// NameLength : length : char
-	s.NameLength = reader.GetChar()
+	nameLength := reader.GetChar()
 	// Name : field : string
-	if s.Name, err = reader.GetFixedString(s.NameLength); err != nil {
+	if s.Name, err = reader.GetFixedString(nameLength); err != nil {
 		return
 	}
 
@@ -419,7 +418,6 @@ func (s *Eif) Deserialize(reader *data.EoReader) (err error) {
 type EnfRecord struct {
 	byteSize int
 
-	NameLength            int
 	Name                  string
 	GraphicId             int
 	Race                  int
@@ -453,11 +451,11 @@ func (s *EnfRecord) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// NameLength : length : char
-	if err = writer.AddChar(s.NameLength); err != nil {
+	if err = writer.AddChar(len(s.Name)); err != nil {
 		return
 	}
 	// Name : field : string
-	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
+	if err = writer.AddFixedString(s.Name, len(s.Name)); err != nil {
 		return
 	}
 	// GraphicId : field : short
@@ -561,9 +559,9 @@ func (s *EnfRecord) Deserialize(reader *data.EoReader) (err error) {
 
 	readerStartPosition := reader.Position()
 	// NameLength : length : char
-	s.NameLength = reader.GetChar()
+	nameLength := reader.GetChar()
 	// Name : field : string
-	if s.Name, err = reader.GetFixedString(s.NameLength); err != nil {
+	if s.Name, err = reader.GetFixedString(nameLength); err != nil {
 		return
 	}
 
@@ -709,7 +707,6 @@ func (s *Enf) Deserialize(reader *data.EoReader) (err error) {
 type EcfRecord struct {
 	byteSize int
 
-	NameLength int
 	Name       string
 	ParentType int
 	StatGroup  int
@@ -731,11 +728,11 @@ func (s *EcfRecord) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// NameLength : length : char
-	if err = writer.AddChar(s.NameLength); err != nil {
+	if err = writer.AddChar(len(s.Name)); err != nil {
 		return
 	}
 	// Name : field : string
-	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
+	if err = writer.AddFixedString(s.Name, len(s.Name)); err != nil {
 		return
 	}
 	// ParentType : field : char
@@ -779,9 +776,9 @@ func (s *EcfRecord) Deserialize(reader *data.EoReader) (err error) {
 
 	readerStartPosition := reader.Position()
 	// NameLength : length : char
-	s.NameLength = reader.GetChar()
+	nameLength := reader.GetChar()
 	// Name : field : string
-	if s.Name, err = reader.GetFixedString(s.NameLength); err != nil {
+	if s.Name, err = reader.GetFixedString(nameLength); err != nil {
 		return
 	}
 
@@ -895,16 +892,14 @@ func (s *Ecf) Deserialize(reader *data.EoReader) (err error) {
 type EsfRecord struct {
 	byteSize int
 
-	NameLength  int
-	ChantLength int
-	Name        string
-	Chant       string
-	IconId      int
-	GraphicId   int
-	TpCost      int
-	SpCost      int
-	CastTime    int
-	Nature      SkillNature
+	Name      string
+	Chant     string
+	IconId    int
+	GraphicId int
+	TpCost    int
+	SpCost    int
+	CastTime  int
+	Nature    SkillNature
 
 	Type           SkillType
 	Element        Element
@@ -941,19 +936,19 @@ func (s *EsfRecord) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	// NameLength : length : char
-	if err = writer.AddChar(s.NameLength); err != nil {
+	if err = writer.AddChar(len(s.Name)); err != nil {
 		return
 	}
 	// ChantLength : length : char
-	if err = writer.AddChar(s.ChantLength); err != nil {
+	if err = writer.AddChar(len(s.Chant)); err != nil {
 		return
 	}
 	// Name : field : string
-	if err = writer.AddFixedString(s.Name, s.NameLength); err != nil {
+	if err = writer.AddFixedString(s.Name, len(s.Name)); err != nil {
 		return
 	}
 	// Chant : field : string
-	if err = writer.AddFixedString(s.Chant, s.ChantLength); err != nil {
+	if err = writer.AddFixedString(s.Chant, len(s.Chant)); err != nil {
 		return
 	}
 	// IconId : field : short
@@ -1085,16 +1080,16 @@ func (s *EsfRecord) Deserialize(reader *data.EoReader) (err error) {
 
 	readerStartPosition := reader.Position()
 	// NameLength : length : char
-	s.NameLength = reader.GetChar()
+	nameLength := reader.GetChar()
 	// ChantLength : length : char
-	s.ChantLength = reader.GetChar()
+	chantLength := reader.GetChar()
 	// Name : field : string
-	if s.Name, err = reader.GetFixedString(s.NameLength); err != nil {
+	if s.Name, err = reader.GetFixedString(nameLength); err != nil {
 		return
 	}
 
 	// Chant : field : string
-	if s.Chant, err = reader.GetFixedString(s.ChantLength); err != nil {
+	if s.Chant, err = reader.GetFixedString(chantLength); err != nil {
 		return
 	}
 

--- a/pkg/eolib/protocol/structs_generated.go
+++ b/pkg/eolib/protocol/structs_generated.go
@@ -4,8 +4,15 @@ import "github.com/ethanmoffat/eolib-go/pkg/eolib/data"
 
 // Coords :: Map coordinates.
 type Coords struct {
+	byteSize int
+
 	X int
 	Y int
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *Coords) ByteSize() int {
+	return s.byteSize
 }
 
 func (s *Coords) Serialize(writer *data.EoWriter) (err error) {
@@ -27,10 +34,12 @@ func (s *Coords) Deserialize(reader *data.EoReader) (err error) {
 	oldIsChunked := reader.IsChunked()
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
+	readerStartPosition := reader.Position()
 	// X : field : char
 	s.X = reader.GetChar()
 	// Y : field : char
 	s.Y = reader.GetChar()
+	s.byteSize = reader.Position() - readerStartPosition
 
 	return
 }


### PR DESCRIPTION
This introduces a number of bug fixes that were discovered when implementing [eolib-dotnet](https://www.github.com/ethanmoffat/eolib-dotnet).

1. Generated code now properly calculates the size of types for deserialization purposes. Previously did not include arrays in size calculations. Generated code now properly moves between chunks, for nested types (switch structs) where 'chunked' is specified in the outer specification.
2. `Remaining()` is now stored in a local variable during deserialization, instead of being accessed in the loop condition. As this value is updated with each read call, only half of the values were being read.
3. Added enforcement of break bytes being part of a chunked section
4. Added `ByteSize` field to all structs. This value is set to the number of bytes read during deserialization. This value is not set if the struct/packet was not deserialized from binary data.
5. Added an assert that fixed-length fields are the correct length. Padded fixed-length fields must not be greater than the specified length.
6. Removed all length properties from code generation. Lengths are now implicit based on the collection.