### PR TITLE
(De)Serialize enums with type size specifiers. Update protocol with bug fixes.

### DIFF
--- a/v3/internal/codegen/struct.go
+++ b/v3/internal/codegen/struct.go
@@ -443,7 +443,11 @@ func writeSerializeBody(g *jen.Group, si *types.StructInfo, fullSpec xml.Protoco
 						).Block(jen.Return()),
 					}
 				} else if e, ok := fullSpec.IsEnum(typeName); ok {
-					if t := types.NewEoType(e.Type); t&types.Primitive > 0 {
+					serializeType := e.Type
+					if typeSize != "" {
+						serializeType = typeSize
+					}
+					if t := types.NewEoType(serializeType); t&types.Primitive > 0 {
 						serializeCodes, err = getSerializeForInstruction(instruction, t, true)
 					}
 				} else {
@@ -676,7 +680,11 @@ func writeDeserializeBody(g *jen.Group, si *types.StructInfo, fullSpec xml.Proto
 						).Block(jen.Return()),
 					}
 				} else if e, ok := fullSpec.IsEnum(typeName); ok {
-					if eoType := types.NewEoType(e.Type); eoType&types.Primitive > 0 {
+					deserializeType := e.Type
+					if typeSize != "" {
+						deserializeType = typeSize
+					}
+					if eoType := types.NewEoType(deserializeType); eoType&types.Primitive > 0 {
 						_, tp := types.ProtocolSpecTypeToGoType(e.Name, si.PackageName, fullSpec)
 						deserializeCodes, err = getDeserializeForInstruction(
 							instruction,

--- a/v3/protocol/net/client/packets_generated.go
+++ b/v3/protocol/net/client/packets_generated.go
@@ -548,7 +548,7 @@ func (s *CharacterCreateClientPacket) Serialize(writer *data.EoWriter) (err erro
 		return
 	}
 	// Gender : field : Gender:short
-	if err = writer.AddChar(int(s.Gender)); err != nil {
+	if err = writer.AddShort(int(s.Gender)); err != nil {
 		return
 	}
 	// HairStyle : field : short
@@ -582,7 +582,7 @@ func (s *CharacterCreateClientPacket) Deserialize(reader *data.EoReader) (err er
 	// SessionId : field : short
 	s.SessionId = reader.GetShort()
 	// Gender : field : Gender:short
-	s.Gender = protocol.Gender(reader.GetChar())
+	s.Gender = protocol.Gender(reader.GetShort())
 	// HairStyle : field : short
 	s.HairStyle = reader.GetShort()
 	// HairColor : field : short

--- a/v3/protocol/net/server/packets_generated.go
+++ b/v3/protocol/net/server/packets_generated.go
@@ -1443,8 +1443,8 @@ func (s *AccountReplyReplyCodeDataChanged) Serialize(writer *data.EoWriter) (err
 	oldSanitizeStrings := writer.SanitizeStrings
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
-	// NO : field : string
-	if err = writer.AddString("NO"); err != nil {
+	// OK : field : string
+	if err = writer.AddString("OK"); err != nil {
 		return
 	}
 	return
@@ -1455,7 +1455,7 @@ func (s *AccountReplyReplyCodeDataChanged) Deserialize(reader *data.EoReader) (e
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
 	readerStartPosition := reader.Position()
-	// NO : field : string
+	// OK : field : string
 	if _, err = reader.GetString(); err != nil {
 		return
 	}
@@ -3518,6 +3518,7 @@ type AdminInteractTellServerPacket struct {
 
 	Name      string
 	Usage     int
+	GoldBank  int
 	Exp       int
 	Level     int
 	MapId     int
@@ -3554,6 +3555,10 @@ func (s *AdminInteractTellServerPacket) Serialize(writer *data.EoWriter) (err er
 		return
 	}
 	writer.AddByte(255)
+	// GoldBank : field : int
+	if err = writer.AddInt(s.GoldBank); err != nil {
+		return
+	}
 	writer.AddByte(255)
 	// Exp : field : int
 	if err = writer.AddInt(s.Exp); err != nil {
@@ -3602,6 +3607,8 @@ func (s *AdminInteractTellServerPacket) Deserialize(reader *data.EoReader) (err 
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
+	// GoldBank : field : int
+	s.GoldBank = reader.GetInt()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}
@@ -6698,7 +6705,6 @@ func (s *ShopOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 		}
 	}
 
-	writer.AddByte(255)
 	writer.SanitizeStrings = false
 	return
 }
@@ -6740,9 +6746,6 @@ func (s *ShopOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 		}
 	}
 
-	if err = reader.NextChunk(); err != nil {
-		return
-	}
 	reader.SetIsChunked(false)
 	s.byteSize = reader.Position() - readerStartPosition
 
@@ -9271,7 +9274,7 @@ func (s *PlayersNet242ServerPacket) Deserialize(reader *data.EoReader) (err erro
 type DoorOpenServerPacket struct {
 	byteSize int
 
-	Coords protocol.Coords
+	Coords protocol.Coords //  The official server erroneously encodes the Y coordinate as a short. The official client reads each coordinate as a char.
 }
 
 func (s DoorOpenServerPacket) Family() net.PacketFamily {
@@ -9295,10 +9298,6 @@ func (s *DoorOpenServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	if err = s.Coords.Serialize(writer); err != nil {
 		return
 	}
-	// 0 : field : char
-	if err = writer.AddChar(0); err != nil {
-		return
-	}
 	return
 }
 
@@ -9311,8 +9310,6 @@ func (s *DoorOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	if err = s.Coords.Deserialize(reader); err != nil {
 		return
 	}
-	// 0 : field : char
-	reader.GetChar()
 	s.byteSize = reader.Position() - readerStartPosition
 
 	return
@@ -13976,6 +13973,10 @@ func (s *RecoverPlayerServerPacket) Serialize(writer *data.EoWriter) (err error)
 	if err = writer.AddShort(s.Tp); err != nil {
 		return
 	}
+	// 0 : field : short
+	if err = writer.AddShort(0); err != nil {
+		return
+	}
 	return
 }
 
@@ -13988,6 +13989,8 @@ func (s *RecoverPlayerServerPacket) Deserialize(reader *data.EoReader) (err erro
 	s.Hp = reader.GetShort()
 	// Tp : field : short
 	s.Tp = reader.GetShort()
+	// 0 : field : short
+	reader.GetShort()
 	s.byteSize = reader.Position() - readerStartPosition
 
 	return

--- a/v3/protocol/pub/structs_generated.go
+++ b/v3/protocol/pub/structs_generated.go
@@ -527,7 +527,7 @@ func (s *EnfRecord) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// Element : field : Element:short
-	if err = writer.AddChar(int(s.Element)); err != nil {
+	if err = writer.AddShort(int(s.Element)); err != nil {
 		return
 	}
 	// ElementDamage : field : short
@@ -535,7 +535,7 @@ func (s *EnfRecord) Serialize(writer *data.EoWriter) (err error) {
 		return
 	}
 	// ElementWeakness : field : Element:short
-	if err = writer.AddChar(int(s.ElementWeakness)); err != nil {
+	if err = writer.AddShort(int(s.ElementWeakness)); err != nil {
 		return
 	}
 	// ElementWeaknessDamage : field : short
@@ -602,11 +602,11 @@ func (s *EnfRecord) Deserialize(reader *data.EoReader) (err error) {
 	// ReturnDamage : field : char
 	s.ReturnDamage = reader.GetChar()
 	// Element : field : Element:short
-	s.Element = Element(reader.GetChar())
+	s.Element = Element(reader.GetShort())
 	// ElementDamage : field : short
 	s.ElementDamage = reader.GetShort()
 	// ElementWeakness : field : Element:short
-	s.ElementWeakness = Element(reader.GetChar())
+	s.ElementWeakness = Element(reader.GetShort())
 	// ElementWeaknessDamage : field : short
 	s.ElementWeaknessDamage = reader.GetShort()
 	// Level : field : char


### PR DESCRIPTION
Type size specifiers were being ignored for enums (e.g. `Gender:short`) so serialize/deserialize calls were producing incorrect data.

eo-protocol has also been updated with a number of fixes.