### PR TITLE
Update protocol to latest commit. Addresses two bugs (SPELL_REPLY and QUEST_REPORT).

### DIFF
--- a/v3/protocol/net/server/packetmap_generated.go
+++ b/v3/protocol/net/server/packetmap_generated.go
@@ -158,6 +158,7 @@ var packetMap = map[int]reflect.Type{
 	net.PacketId(net.PacketFamily_Avatar, net.PacketAction_Admin):         reflect.TypeOf(AvatarAdminServerPacket{}),
 	net.PacketId(net.PacketFamily_Spell, net.PacketAction_TargetGroup):    reflect.TypeOf(SpellTargetGroupServerPacket{}),
 	net.PacketId(net.PacketFamily_Spell, net.PacketAction_TargetOther):    reflect.TypeOf(SpellTargetOtherServerPacket{}),
+	net.PacketId(net.PacketFamily_Spell, net.PacketAction_Reply):          reflect.TypeOf(SpellReplyServerPacket{}),
 	net.PacketId(net.PacketFamily_Trade, net.PacketAction_Request):        reflect.TypeOf(TradeRequestServerPacket{}),
 	net.PacketId(net.PacketFamily_Trade, net.PacketAction_Open):           reflect.TypeOf(TradeOpenServerPacket{}),
 	net.PacketId(net.PacketFamily_Trade, net.PacketAction_Reply):          reflect.TypeOf(TradeReplyServerPacket{}),

--- a/v3/protocol/net/server/packets_generated.go
+++ b/v3/protocol/net/server/packets_generated.go
@@ -11841,6 +11841,63 @@ func (s *SpellTargetOtherServerPacket) Deserialize(reader *data.EoReader) (err e
 	return
 }
 
+// SpellReplyServerPacket :: Your character self-cast a targetable heal spell.
+type SpellReplyServerPacket struct {
+	byteSize int
+
+	SpellId int
+	Hp      int
+	Tp      int
+}
+
+func (s SpellReplyServerPacket) Family() net.PacketFamily {
+	return net.PacketFamily_Spell
+}
+
+func (s SpellReplyServerPacket) Action() net.PacketAction {
+	return net.PacketAction_Reply
+}
+
+// ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
+func (s *SpellReplyServerPacket) ByteSize() int {
+	return s.byteSize
+}
+
+func (s *SpellReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
+	oldSanitizeStrings := writer.SanitizeStrings
+	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
+
+	// SpellId : field : short
+	if err = writer.AddShort(s.SpellId); err != nil {
+		return
+	}
+	// Hp : field : short
+	if err = writer.AddShort(s.Hp); err != nil {
+		return
+	}
+	// Tp : field : short
+	if err = writer.AddShort(s.Tp); err != nil {
+		return
+	}
+	return
+}
+
+func (s *SpellReplyServerPacket) Deserialize(reader *data.EoReader) (err error) {
+	oldIsChunked := reader.IsChunked()
+	defer func() { reader.SetIsChunked(oldIsChunked) }()
+
+	readerStartPosition := reader.Position()
+	// SpellId : field : short
+	s.SpellId = reader.GetShort()
+	// Hp : field : short
+	s.Hp = reader.GetShort()
+	// Tp : field : short
+	s.Tp = reader.GetShort()
+	s.byteSize = reader.Position() - readerStartPosition
+
+	return
+}
+
 // TradeRequestServerPacket :: Trade request from another player.
 type TradeRequestServerPacket struct {
 	byteSize int
@@ -12968,7 +13025,7 @@ func (s *NpcDialogServerPacket) Deserialize(reader *data.EoReader) (err error) {
 type QuestReportServerPacket struct {
 	byteSize int
 
-	NpcId    int
+	NpcIndex int
 	Messages []string
 }
 
@@ -12990,8 +13047,8 @@ func (s *QuestReportServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	writer.SanitizeStrings = true
-	// NpcId : field : short
-	if err = writer.AddShort(s.NpcId); err != nil {
+	// NpcIndex : field : short
+	if err = writer.AddShort(s.NpcIndex); err != nil {
 		return
 	}
 	writer.AddByte(255)
@@ -13013,8 +13070,8 @@ func (s *QuestReportServerPacket) Deserialize(reader *data.EoReader) (err error)
 
 	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
-	// NpcId : field : short
-	s.NpcId = reader.GetShort()
+	// NpcIndex : field : short
+	s.NpcIndex = reader.GetShort()
 	if err = reader.NextChunk(); err != nil {
 		return
 	}


### PR DESCRIPTION
1. Add representation for SPELL_REPLY server packet. This structure was erroneously omitted from the eo-protocol files.
2. Rename NpcId -> NpcIndex in QUEST_REPORT server packet. This more accurately reflects the function of the member.