### PR TITLE
Update protocol to latest (as of 2024-08-21)

### DIFF
--- a/v3/protocol/net/server/packets_generated.go
+++ b/v3/protocol/net/server/packets_generated.go
@@ -12043,7 +12043,7 @@ func (s *TradeOpenServerPacket) Deserialize(reader *data.EoReader) (err error) {
 type TradeReplyServerPacket struct {
 	byteSize int
 
-	TradeData TradeItemData
+	TradeData []TradeItemData
 }
 
 func (s TradeReplyServerPacket) Family() net.PacketFamily {
@@ -12063,10 +12063,18 @@ func (s *TradeReplyServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	oldSanitizeStrings := writer.SanitizeStrings
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
-	// TradeData : field : TradeItemData
-	if err = s.TradeData.Serialize(writer); err != nil {
-		return
+	// TradeData : array : TradeItemData
+	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.TradeData) != 2 {
+			err = fmt.Errorf("expected TradeData with length 2, got %d", len(s.TradeData))
+			return
+		}
+
+		if err = s.TradeData[ndx].Serialize(writer); err != nil {
+			return
+		}
 	}
+
 	return
 }
 
@@ -12075,10 +12083,14 @@ func (s *TradeReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
 	readerStartPosition := reader.Position()
-	// TradeData : field : TradeItemData
-	if err = s.TradeData.Deserialize(reader); err != nil {
-		return
+	// TradeData : array : TradeItemData
+	for ndx := 0; ndx < 2; ndx++ {
+		s.TradeData = append(s.TradeData, TradeItemData{})
+		if err = s.TradeData[ndx].Deserialize(reader); err != nil {
+			return
+		}
 	}
+
 	s.byteSize = reader.Position() - readerStartPosition
 
 	return
@@ -12088,7 +12100,7 @@ func (s *TradeReplyServerPacket) Deserialize(reader *data.EoReader) (err error) 
 type TradeAdminServerPacket struct {
 	byteSize int
 
-	TradeData TradeItemData
+	TradeData []TradeItemData
 }
 
 func (s TradeAdminServerPacket) Family() net.PacketFamily {
@@ -12108,10 +12120,18 @@ func (s *TradeAdminServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	oldSanitizeStrings := writer.SanitizeStrings
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
-	// TradeData : field : TradeItemData
-	if err = s.TradeData.Serialize(writer); err != nil {
-		return
+	// TradeData : array : TradeItemData
+	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.TradeData) != 2 {
+			err = fmt.Errorf("expected TradeData with length 2, got %d", len(s.TradeData))
+			return
+		}
+
+		if err = s.TradeData[ndx].Serialize(writer); err != nil {
+			return
+		}
 	}
+
 	return
 }
 
@@ -12120,10 +12140,14 @@ func (s *TradeAdminServerPacket) Deserialize(reader *data.EoReader) (err error) 
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
 	readerStartPosition := reader.Position()
-	// TradeData : field : TradeItemData
-	if err = s.TradeData.Deserialize(reader); err != nil {
-		return
+	// TradeData : array : TradeItemData
+	for ndx := 0; ndx < 2; ndx++ {
+		s.TradeData = append(s.TradeData, TradeItemData{})
+		if err = s.TradeData[ndx].Deserialize(reader); err != nil {
+			return
+		}
 	}
+
 	s.byteSize = reader.Position() - readerStartPosition
 
 	return
@@ -12133,7 +12157,7 @@ func (s *TradeAdminServerPacket) Deserialize(reader *data.EoReader) (err error) 
 type TradeUseServerPacket struct {
 	byteSize int
 
-	TradeData TradeItemData
+	TradeData []TradeItemData
 }
 
 func (s TradeUseServerPacket) Family() net.PacketFamily {
@@ -12153,10 +12177,18 @@ func (s *TradeUseServerPacket) Serialize(writer *data.EoWriter) (err error) {
 	oldSanitizeStrings := writer.SanitizeStrings
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
-	// TradeData : field : TradeItemData
-	if err = s.TradeData.Serialize(writer); err != nil {
-		return
+	// TradeData : array : TradeItemData
+	for ndx := 0; ndx < 2; ndx++ {
+		if len(s.TradeData) != 2 {
+			err = fmt.Errorf("expected TradeData with length 2, got %d", len(s.TradeData))
+			return
+		}
+
+		if err = s.TradeData[ndx].Serialize(writer); err != nil {
+			return
+		}
 	}
+
 	return
 }
 
@@ -12165,10 +12197,14 @@ func (s *TradeUseServerPacket) Deserialize(reader *data.EoReader) (err error) {
 	defer func() { reader.SetIsChunked(oldIsChunked) }()
 
 	readerStartPosition := reader.Position()
-	// TradeData : field : TradeItemData
-	if err = s.TradeData.Deserialize(reader); err != nil {
-		return
+	// TradeData : array : TradeItemData
+	for ndx := 0; ndx < 2; ndx++ {
+		s.TradeData = append(s.TradeData, TradeItemData{})
+		if err = s.TradeData[ndx].Deserialize(reader); err != nil {
+			return
+		}
 	}
+
 	s.byteSize = reader.Position() - readerStartPosition
 
 	return

--- a/v3/protocol/net/server/structs_generated.go
+++ b/v3/protocol/net/server/structs_generated.go
@@ -3178,10 +3178,8 @@ func (s *GroupHealTargetPlayer) Deserialize(reader *data.EoReader) (err error) {
 type TradeItemData struct {
 	byteSize int
 
-	PartnerPlayerId int
-	PartnerItems    []net.Item
-	YourPlayerId    int
-	YourItems       []net.Item
+	PlayerId int
+	Items    []net.Item
 }
 
 // ByteSize gets the deserialized size of this object. This value is zero for an object that was not deserialized from data.
@@ -3194,25 +3192,13 @@ func (s *TradeItemData) Serialize(writer *data.EoWriter) (err error) {
 	defer func() { writer.SanitizeStrings = oldSanitizeStrings }()
 
 	writer.SanitizeStrings = true
-	// PartnerPlayerId : field : short
-	if err = writer.AddShort(s.PartnerPlayerId); err != nil {
+	// PlayerId : field : short
+	if err = writer.AddShort(s.PlayerId); err != nil {
 		return
 	}
-	// PartnerItems : array : Item
-	for ndx := 0; ndx < len(s.PartnerItems); ndx++ {
-		if err = s.PartnerItems[ndx].Serialize(writer); err != nil {
-			return
-		}
-	}
-
-	writer.AddByte(255)
-	// YourPlayerId : field : short
-	if err = writer.AddShort(s.YourPlayerId); err != nil {
-		return
-	}
-	// YourItems : array : Item
-	for ndx := 0; ndx < len(s.YourItems); ndx++ {
-		if err = s.YourItems[ndx].Serialize(writer); err != nil {
+	// Items : array : Item
+	for ndx := 0; ndx < len(s.Items); ndx++ {
+		if err = s.Items[ndx].Serialize(writer); err != nil {
 			return
 		}
 	}
@@ -3228,27 +3214,13 @@ func (s *TradeItemData) Deserialize(reader *data.EoReader) (err error) {
 
 	readerStartPosition := reader.Position()
 	reader.SetIsChunked(true)
-	// PartnerPlayerId : field : short
-	s.PartnerPlayerId = reader.GetShort()
-	// PartnerItems : array : Item
-	PartnerItemsRemaining := reader.Remaining()
-	for ndx := 0; ndx < PartnerItemsRemaining/6; ndx++ {
-		s.PartnerItems = append(s.PartnerItems, net.Item{})
-		if err = s.PartnerItems[ndx].Deserialize(reader); err != nil {
-			return
-		}
-	}
-
-	if err = reader.NextChunk(); err != nil {
-		return
-	}
-	// YourPlayerId : field : short
-	s.YourPlayerId = reader.GetShort()
-	// YourItems : array : Item
-	YourItemsRemaining := reader.Remaining()
-	for ndx := 0; ndx < YourItemsRemaining/6; ndx++ {
-		s.YourItems = append(s.YourItems, net.Item{})
-		if err = s.YourItems[ndx].Deserialize(reader); err != nil {
+	// PlayerId : field : short
+	s.PlayerId = reader.GetShort()
+	// Items : array : Item
+	ItemsRemaining := reader.Remaining()
+	for ndx := 0; ndx < ItemsRemaining/6; ndx++ {
+		s.Items = append(s.Items, net.Item{})
+		if err = s.Items[ndx].Deserialize(reader); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
Update format for trade structures/packets to use array instead of individual player IDs and item lists. Removes "your" and "partner" data members in favor of generic fixed-size array with two sets of player info.